### PR TITLE
docs(release): :memo: simplified readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,42 @@
-# backstage-plugin-backend
+# PagerDuty plugin for Backstage - Backend
 
-Welcome to the backstage-plugin-backend backend plugin!
+[![Release](https://github.com/PagerDuty/backstage-plugin-backend/actions/workflows/on_release_created.yml/badge.svg)](https://github.com/PagerDuty/backstage-plugin-backend/actions/workflows/on_release_created.yml)
+[![npm version](https://badge.fury.io/js/@pagerduty%2Fbackstage-plugin-backend.svg)](https://badge.fury.io/js/@pagerduty%2Fbackstage-plugin-backend)
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
-_This plugin was created through the Backstage CLI_
+**Bring the power of PagerDuty to Backstage!**
+The PagerDuty backend plugin reduces the cognitive load on developers responsible for maintaining services in production. Instead of having to go to PagerDuty's console, you can now access the necessary information directly within Backstage. This includes finding active incidents or opening a new incident, reviewing recent changes made to the service, and checking who is on-call.
 
-## Getting started
+The PagerDuty backend plugin augments the capabilities of the [PagerDuty frontend plugin](https://github.com/PagerDuty/backstage-plugin) by improving security and enabling PagerDuty a standardization through easy configuration.
 
-Your plugin has been added to the example app in this repository, meaning you'll be able to access it by running `yarn
-start` in the root directory, and then navigating to [/backstage-plugin-backend](http://localhost:3000/backstage-plugin-backend).
+## Features
 
-You can also serve the plugin in isolation by running `yarn start` in the plugin directory.
-This method of serving the plugin provides quicker iteration speed and a faster startup and hot reloads.
-It is only meant for local development, and the setup for it can be found inside the [/dev](/dev) directory.
+- **Scaffolder Action for creating services** This feature enables teams to create project templates that automatically generate a corresponding service in PagerDuty. These services come with a built-in integration to Backstage, which conveniently configures the frontend plugin for your service.
+
+## Getting Started
+
+Find the complete project's documentation [here](https://pagerduty.github.io/backstage-plugin-docs/).
+
+### Installation
+
+The installation of the PagerDuty plugin for Backstage is done with *yarn* as all other plugins in Backstage. This plugin follows a modular approach which means that every individual component will be a separate package (e.g. frontend, backend, common). In this case, you are installing a **backend plugin**.
+
+To install this plugin run the following command from the Backstage root folder.
+
+```bash
+yarn add --cwd packages/backend @pagerduty/backstage-plugin-backend
+```
+
+### Configuration
+
+To use the custom actions as part of your custom project templates follow the instructions on the `` section of the project's documentation [here](https://pagerduty.github.io/backstage-plugin-docs/).
+
+
+## Support
+
+If you need help with this plugin, please open an issue in [GitHub](https://github.com/PagerDuty/backstage-plugin-backend), reach out on the [Backstage Discord server](https://discord.gg/backstage-687207715902193673) or [PagerDuty's community forum](https://community.pagerduty.com).
+
+## Contributing
+
+If you are interested in contributing to this project, please refer to our [Contributing Guidelines](https://github.com/PagerDuty/backstage-plugin-backend/blob/main/CONTRIBUTING.md).
+


### PR DESCRIPTION
Simplified ReadMe.md because documentation is moved to [docs project](https://github.com/PagerDuty/backstage-plugin-docs).