### PR TITLE
improv(ux): Adding support for escalation policy dropdown on custom action

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,7 @@ yarn add --cwd packages/backend @pagerduty/backstage-plugin-backend
 
 ### Configuration
 
-To use the custom actions as part of your custom project templates follow the instructions on the `Create PagerDuty service with Software Templates` section of the project's documentation [here](https://pagerduty.github.io/backstage-plugin-docs/).
-
+To use the custom actions as part of your custom project templates follow the instructions on the `Create PagerDuty service with Software Templates` section of the project's documentation [here](https://pagerduty.github.io/backstage-plugin-docs/advanced/create-service-software-template/).
 
 ## Support
 

--- a/config.d.ts
+++ b/config.d.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export interface Config {
+    /**
+     * Configuration for the PagerDuty plugin
+     * @visibility frontend
+     */
+    pagerDuty?: {
+        /**
+         * Optional Events Base URL to override the default.
+         * @visibility frontend
+         */
+        eventsBaseUrl?: string;
+        /**
+         * Optional PagerDuty API Token used in API calls from the backend component.
+         * @visibility frontend
+         */
+        apiToken?: string;
+    };
+}

--- a/package.json
+++ b/package.json
@@ -46,7 +46,9 @@
     "typescript": "^4.8.4"
   },
   "files": [
-    "dist"
+    "dist",
+    "config.d.ts"
   ],
+  "configSchema": "config.d.ts",
   "packageManager": "yarn@3.6.3"
 }

--- a/src/apis/pagerduty.test.ts
+++ b/src/apis/pagerduty.test.ts
@@ -219,7 +219,7 @@ describe("PagerDuty API", () => {
 
             const expectedResponse = [
                 {
-                    id: expectedId, 
+                    id: expectedId,
                     name: expectedName
                 }
             ];
@@ -316,6 +316,147 @@ describe("PagerDuty API", () => {
                 expect(((error as HttpError).status)).toEqual(expectedStatusCode);
                 expect(((error as HttpError).message)).toEqual(expectedErrorMessage);
             }
+        });
+
+        it("should work with pagination", async () => {
+            const expectedId = ["P0L1CY1D1", "P0L1CY1D2", "P0L1CY1D3", "P0L1CY1D4", "P0L1CY1D5", "P0L1CY1D6", "P0L1CY1D7", "P0L1CY1D8", "P0L1CY1D9", "P0L1CY1D10"];
+            const expectedName = ["Test Escalation Policy 1", "Test Escalation Policy 2", "Test Escalation Policy 3", "Test Escalation Policy 4", "Test Escalation Policy 5", "Test Escalation Policy 6", "Test Escalation Policy 7", "Test Escalation Policy 8", "Test Escalation Policy 9", "Test Escalation Policy 10"];
+
+            const expectedResponse = [
+                {
+                    id: expectedId[0],
+                    name: expectedName[0]
+                },
+                {
+                    id: expectedId[1],
+                    name: expectedName[1]
+                },
+                {
+                    id: expectedId[2],
+                    name: expectedName[2]
+                },
+                {
+                    id: expectedId[3],
+                    name: expectedName[3]
+                },
+                {
+                    id: expectedId[4],
+                    name: expectedName[4]
+                },
+                {
+                    id: expectedId[5],
+                    name: expectedName[5]
+                },
+                {
+                    id: expectedId[6],
+                    name: expectedName[6]
+                },
+                {
+                    id: expectedId[7],
+                    name: expectedName[7]
+                },
+                {
+                    id: expectedId[8],
+                    name: expectedName[8]
+                },
+                {
+                    id: expectedId[9],
+                    name: expectedName[9]
+                }
+            ];
+
+            global.fetch = jest.fn().mockReturnValueOnce(
+                Promise.resolve({
+                    status: 200,
+                    json: () => Promise.resolve({
+                        escalation_policies: [
+                            {
+                                id: expectedId[0],
+                                name: expectedName[0],
+                            },
+                            {
+                                id: expectedId[1],
+                                name: expectedName[1],
+                            }
+                        ],
+                        more: true
+                    })
+                })
+            ).mockReturnValueOnce(
+                Promise.resolve({
+                    status: 200,
+                    json: () => Promise.resolve({
+                        escalation_policies: [
+                            {
+                                id: expectedId[2],
+                                name: expectedName[2],
+                            },
+                            {
+                                id: expectedId[3],
+                                name: expectedName[3],
+                            }
+                        ],
+                        more: true
+                    })
+                })
+            ).mockReturnValueOnce(
+                Promise.resolve({
+                    status: 200,
+                    json: () => Promise.resolve({
+                        escalation_policies: [
+                            {
+                                id: expectedId[4],
+                                name: expectedName[4],
+                            },
+                            {
+                                id: expectedId[5],
+                                name: expectedName[5],
+                            }
+                        ],
+                        more: true
+                    })
+                })
+            ).mockReturnValueOnce(
+                Promise.resolve({
+                    status: 200,
+                    json: () => Promise.resolve({
+                        escalation_policies: [
+                            {
+                                id: expectedId[6],
+                                name: expectedName[6],
+                            },
+                            {
+                                id: expectedId[7],
+                                name: expectedName[7],
+                            }
+                        ],
+                        more: true
+                    })
+                })
+            ).mockReturnValueOnce(
+                Promise.resolve({
+                    status: 200,
+                    json: () => Promise.resolve({
+                        escalation_policies: [
+                            {
+                                id: expectedId[8],
+                                name: expectedName[8],
+                            },
+                            {
+                                id: expectedId[9],
+                                name: expectedName[9],
+                            }
+                        ],
+                        more: false
+                    })
+                })
+            ) as jest.Mock;
+
+            const result = await getAllEscalationPolicies();
+
+            expect(result).toEqual(expectedResponse);
+            expect(result.length).toEqual(10);
+            expect(fetch).toHaveBeenCalledTimes(5);
         });
     });
 });

--- a/src/apis/pagerduty.test.ts
+++ b/src/apis/pagerduty.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable jest/no-conditional-expect */
-import { createService, createServiceIntegration } from "./pagerduty";
+import { HttpError } from "../types";
+import { createService, createServiceIntegration, getAllEscalationPolicies } from "./pagerduty";
 
 describe("PagerDuty API", () => {
     afterEach(() => {
@@ -141,14 +142,15 @@ describe("PagerDuty API", () => {
             global.fetch = jest.fn(() =>
                 Promise.resolve({
                     status: 400,
-                    json: () => Promise.resolve({})
                 })
             ) as jest.Mock;
+
+            const expectedErrorMessage = "Failed to create service integration. Caller provided invalid arguments.";
 
             try {
                 await createServiceIntegration(serviceId, vendorId);
             } catch (error) {
-                expect(((error as Error).message)).toEqual("Failed to create service integration. Caller provided invalid arguments.");
+                expect(((error as Error).message)).toEqual(expectedErrorMessage);
             }
         });
 
@@ -158,15 +160,16 @@ describe("PagerDuty API", () => {
 
             global.fetch = jest.fn(() =>
                 Promise.resolve({
-                    status: 401,
-                    json: () => Promise.resolve({})
+                    status: 401
                 })
             ) as jest.Mock;
+
+            const expectedErrorMessage = "Failed to create service integration. Caller did not supply credentials or did not provide the correct credentials.";
 
             try {
                 await createServiceIntegration(serviceId, vendorId);
             } catch (error) {
-                expect(((error as Error).message)).toEqual("Failed to create service integration. Caller did not supply credentials or did not provide the correct credentials.");
+                expect(((error as Error).message)).toEqual(expectedErrorMessage);
             }
         });
 
@@ -176,15 +179,16 @@ describe("PagerDuty API", () => {
 
             global.fetch = jest.fn(() =>
                 Promise.resolve({
-                    status: 403,
-                    json: () => Promise.resolve({})
+                    status: 403
                 })
             ) as jest.Mock;
+
+            const expectedErrorMessage = "Failed to create service integration. Caller is not authorized to view the requested resource.";
 
             try {
                 await createServiceIntegration(serviceId, vendorId);
             } catch (error) {
-                expect(((error as Error).message)).toEqual("Failed to create service integration. Caller is not authorized to view the requested resource.");
+                expect(((error as Error).message)).toEqual(expectedErrorMessage);
             }
         });
 
@@ -194,15 +198,123 @@ describe("PagerDuty API", () => {
 
             global.fetch = jest.fn(() =>
                 Promise.resolve({
-                    status: 429,
-                    json: () => Promise.resolve({})
+                    status: 429
                 })
             ) as jest.Mock;
+
+            const expectedErrorMessage = "Failed to create service integration. Rate limit exceeded.";
 
             try {
                 await createServiceIntegration(serviceId, vendorId);
             } catch (error) {
-                expect(((error as Error).message)).toEqual("Failed to create service integration. Rate limit exceeded.");
+                expect(((error as Error).message)).toEqual(expectedErrorMessage);
+            }
+        });
+    });
+
+    describe("getAllEscalationPolicies", () => {
+        it("should return ok", async () => {
+            const expectedId = "P0L1CY1D";
+            const expectedName = "Test Escalation Policy";
+
+            const expectedResponse = [
+                {
+                    id: expectedId, 
+                    name: expectedName
+                }
+            ];
+
+            global.fetch = jest.fn(() =>
+                Promise.resolve({
+                    status: 200,
+                    json: () => Promise.resolve({
+                        escalation_policies: [
+                            {
+                                id: expectedId,
+                                name: expectedName,
+                            }
+                        ]
+                    })
+                })
+            ) as jest.Mock;
+
+            const result = await getAllEscalationPolicies();
+
+            expect(result).toEqual(expectedResponse);
+            expect(result.length).toEqual(1);
+            expect(fetch).toHaveBeenCalledTimes(1);
+        });
+
+        it("should NOT list escalation policies when caller provides invalid arguments", async () => {
+            global.fetch = jest.fn(() =>
+                Promise.resolve({
+                    status: 400,
+                    json: () => Promise.resolve({})
+                })
+            ) as jest.Mock;
+
+            const expectedStatusCode = 400;
+            const expectedErrorMessage = "Failed to list escalation policies. Caller provided invalid arguments.";
+
+            try {
+                await getAllEscalationPolicies();
+            } catch (error) {
+                expect(((error as HttpError).status)).toEqual(expectedStatusCode);
+                expect(((error as HttpError).message)).toEqual(expectedErrorMessage);
+            }
+        });
+
+        it("should NOT list escalation policies when correct credentials are not provided", async () => {
+            global.fetch = jest.fn(() =>
+                Promise.resolve({
+                    status: 401
+                })
+            ) as jest.Mock;
+
+            const expectedStatusCode = 401;
+            const expectedErrorMessage = "Failed to list escalation policies. Caller did not supply credentials or did not provide the correct credentials.";
+
+            try {
+                await getAllEscalationPolicies();
+            } catch (error) {
+                expect(((error as HttpError).status)).toEqual(expectedStatusCode);
+                expect(((error as HttpError).message)).toEqual(expectedErrorMessage);
+            }
+        });
+
+        it("should NOT list escalation policies when account does not have abilities to perform the action", async () => {
+            global.fetch = jest.fn(() =>
+                Promise.resolve({
+                    status: 403
+                })
+            ) as jest.Mock;
+
+            const expectedStatusCode = 403;
+            const expectedErrorMessage = "Failed to list escalation policies. Caller is not authorized to view the requested resource.";
+
+            try {
+                await getAllEscalationPolicies();
+            } catch (error) {
+                expect(((error as HttpError).status)).toEqual(expectedStatusCode);
+                expect(((error as HttpError).message)).toEqual(expectedErrorMessage);
+            }
+        });
+
+        it("should NOT list escalation policies when user is not allowed to view the requested resource", async () => {
+            global.fetch = jest.fn(() =>
+                Promise.resolve({
+                    status: 429
+                })
+            ) as jest.Mock;
+
+            const expectedStatusCode = 429;
+            const expectedErrorMessage = "Failed to list escalation policies. Rate limit exceeded.";
+
+            try {
+                await getAllEscalationPolicies();
+            } catch (error) {
+                expect(((error as HttpError).status)).toEqual(expectedStatusCode);
+                expect(((error as HttpError).message)).toEqual(expectedErrorMessage);
             }
         });
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
-// export * from './service/router';
+export * from './service/router';
 export * from './actions/custom';

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,15 +1,15 @@
 import { getRootLogger } from '@backstage/backend-common';
-// import yn from 'yn';
-// import { startStandaloneServer } from './service/standaloneServer';
+import yn from 'yn';
+import { startStandaloneServer } from './service/standaloneServer';
 
-// const port = process.env.PLUGIN_PORT ? Number(process.env.PLUGIN_PORT) : 7007;
-// const enableCors = yn(process.env.PLUGIN_CORS, { default: false });
+const port = process.env.PLUGIN_PORT ? Number(process.env.PLUGIN_PORT) : 7007;
+const enableCors = yn(process.env.PLUGIN_CORS, { default: false });
 const logger = getRootLogger();
 
-// startStandaloneServer({ port, enableCors, logger }).catch(err => {
-//   logger.error(err);
-//   process.exit(1);
-// });
+startStandaloneServer({ port, enableCors, logger }).catch(err => {
+  logger.error(err);
+  process.exit(1);
+});
 
 process.on('SIGINT', () => {
   logger.info('CTRL+C pressed; exiting.');

--- a/src/service/router.test.ts
+++ b/src/service/router.test.ts
@@ -1,0 +1,97 @@
+import { getVoidLogger } from '@backstage/backend-common';
+import { ConfigReader } from '@backstage/config';
+import express from 'express';
+import request from 'supertest';
+
+import { createRouter } from './router';
+import { PagerDutyEscalationPolicy } from '../types';
+
+describe('createRouter', () => {
+  let app: express.Express;
+
+  beforeAll(async () => {
+    const router = await createRouter(
+      {
+        logger: getVoidLogger(),
+        config: new ConfigReader({
+          app: {
+            baseUrl: 'https://example.com/extra-path',
+          },
+          pagerDuty: {
+            apiToken: `${process.env.PAGERDUTY_TOKEN}`,
+          },
+        }),
+      }
+    );
+    app = express().use(router);
+  });
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('GET /health', () => {
+    it('returns ok', async () => {
+      const response = await request(app).get('/health');
+
+      expect(response.status).toEqual(200);
+      expect(response.body).toEqual({ status: 'ok' });
+    });
+  });
+
+  describe('GET /escalation_policies', () => {
+    it('returns ok', async () => {
+      global.fetch = jest.fn(() =>
+        Promise.resolve({
+          status: 200,
+          json: () => Promise.resolve({
+            escalation_policies: [
+              {
+                id: "12345",
+                name: "Test Escalation Policy",
+                type: "escalation_policy",
+                summary: "Test Escalation Policy",
+                self: "https://api.pagerduty.com/escalation_policies/12345",
+                html_url: "https://example.pagerduty.com/escalation_policies/12345",
+              } 
+            ]
+          })
+        })
+      ) as jest.Mock;
+
+      const expectedStatusCode = 200;
+      const expectedResponse = [
+        {
+          label: "Test Escalation Policy",
+          value: "12345",
+        }
+      ];
+
+      const response = await request(app).get('/escalation_policies');
+
+      const policies: PagerDutyEscalationPolicy[] = JSON.parse(response.text);
+
+      expect(response.status).toEqual(expectedStatusCode);
+      expect(response.body).toEqual(expectedResponse);
+      expect(policies.length).toEqual(1);
+    });
+
+    it('returns unauthorized', async () => {
+      global.fetch = jest.fn(() =>
+        Promise.resolve({
+          status: 401
+        })
+      ) as jest.Mock;
+
+      const expectedStatusCode = 401;
+      const expectedErrorMessage = "Failed to list escalation policies. Caller did not supply credentials or did not provide the correct credentials.";
+
+      const response = await request(app).get('/escalation_policies');
+
+      expect(response.status).toEqual(expectedStatusCode);
+      expect(response.text).toMatch(expectedErrorMessage);
+    });
+
+    
+  });
+});

--- a/src/service/router.test.ts
+++ b/src/service/router.test.ts
@@ -28,7 +28,7 @@ describe('createRouter', () => {
 
   beforeEach(() => {
     jest.resetAllMocks();
-  });
+  });  
 
   describe('GET /health', () => {
     it('returns ok', async () => {
@@ -53,7 +53,7 @@ describe('createRouter', () => {
                 summary: "Test Escalation Policy",
                 self: "https://api.pagerduty.com/escalation_policies/12345",
                 html_url: "https://example.pagerduty.com/escalation_policies/12345",
-              } 
+              }
             ]
           })
         })
@@ -91,7 +91,27 @@ describe('createRouter', () => {
       expect(response.status).toEqual(expectedStatusCode);
       expect(response.text).toMatch(expectedErrorMessage);
     });
-
     
+    it('returns empty list when no escalation policies exist', async () => {
+      global.fetch = jest.fn(() =>
+        Promise.resolve({
+          status: 200,
+          json: () => Promise.resolve({
+            escalation_policies: []
+          })
+        })
+      ) as jest.Mock;
+
+      const expectedStatusCode = 200;
+      const expectedResponse: PagerDutyEscalationPolicy[] = [];
+
+      const response = await request(app).get('/escalation_policies');
+
+      const policies: PagerDutyEscalationPolicy[] = JSON.parse(response.text);
+
+      expect(response.status).toEqual(expectedStatusCode);
+      expect(response.body).toEqual(expectedResponse);
+      expect(policies.length).toEqual(0);
+    });
   });
 });

--- a/src/service/router.ts
+++ b/src/service/router.ts
@@ -1,0 +1,53 @@
+import { errorHandler } from '@backstage/backend-common';
+import { Config } from '@backstage/config';
+import express from 'express';
+import Router from 'express-promise-router';
+import { Logger } from 'winston';
+import { getAllEscalationPolicies } from '../apis/pagerduty';
+import { HttpError } from '../types';
+
+export interface RouterOptions {
+    logger: Logger;
+    config: Config;
+}
+
+export async function createRouter(
+    options: RouterOptions
+): Promise<express.Router> {
+    const { logger, config } = options;
+
+    if (config.getOptionalString('pagerDuty.apiToken') === undefined) {
+        throw new Error('No PagerDuty API token was provided.');
+    }
+    process.env.PAGERDUTY_TOKEN = `${config.getOptionalString('pagerDuty.apiToken')}`;
+
+    const router = Router();
+    router.use(express.json());
+
+    router.get('/escalation_policies', async (_, response) => {
+        logger.info('Getting escalation policies');
+
+        try {
+            const escalationPolicyList = await getAllEscalationPolicies();
+            const escalationPolicyDropDownOptions = escalationPolicyList.map((policy) => {
+                return {
+                    label: policy.name,
+                    value: policy.id,
+                };
+            });
+
+            response.json(escalationPolicyDropDownOptions);
+        } catch (error) {
+            if (error instanceof HttpError) {
+                response.status(error.status).json(`${error.message}`);
+            }
+        }
+    });
+
+    router.get('/health', async (_, response) => {
+        response.status(200).json({ status: 'ok' });
+    });
+
+    router.use(errorHandler());
+    return router;
+}

--- a/src/service/standaloneServer.ts
+++ b/src/service/standaloneServer.ts
@@ -1,0 +1,38 @@
+import { createServiceBuilder, loadBackendConfig } from '@backstage/backend-common';
+import { Server } from 'http';
+import { Logger } from 'winston';
+import { createRouter } from './router';
+
+export interface ServerOptions {
+  port: number;
+  enableCors: boolean;
+  logger: Logger;
+}
+
+export async function startStandaloneServer(
+  options: ServerOptions,
+): Promise<Server> {
+  const logger = options.logger.child({ service: '@pagerduty/backstage-plugin-backend' });
+  const config = await loadBackendConfig({ logger, argv: process.argv });
+  logger.debug('Starting application server...');
+  const router = await createRouter(
+    {
+      logger,
+      config,
+    }
+  );
+
+  let service = createServiceBuilder(module)
+    .setPort(options.port)
+    .addRouter('/pagerduty', router);
+  if (options.enableCors) {
+    service = service.enableCors({ origin: 'http://localhost:3000' });
+  }
+
+  return await service.start().catch(err => {
+    logger.error(err);
+    process.exit(1);
+  });
+}
+
+module.hot?.accept();

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,6 +28,7 @@ export type PagerDutyTeam = {
 
 export type PagerDutyEscalationPolicy = {
     id: string;
+    name: string;
     type: string;
     summary: string;
     self: string;
@@ -71,3 +72,27 @@ export type PagerDutyVendor = {
     self: string;
     htmlUrl: string;
 };
+
+export type PagerDutyEscalationPolicyListResponse = {
+    escalation_policies: PagerDutyEscalationPolicy[];
+    limit: number;
+    offset: number;
+    more: boolean;
+    total: number;
+};
+
+export type PagerDutyEscalationPolicyDropDownOption = {
+    label: string;
+    value: string;
+};
+
+export class HttpError extends Error {
+    constructor(message: string, status: number) {
+        super(message);
+        this.status = status;
+    }
+
+    status: number;
+}
+
+


### PR DESCRIPTION
### Description

This PR introduces the capability of replacing the Escalation Policy ID input in the 'pagerduty:service:create' action with a drop-down with the Escalation Policies available to the user. It does so by exposing a local API that gets all escalation policies and returns a list of names and ids.

It introduces a new configuration option (apiToken) documented as part of Backstage configuration schema. Without it the plugin is unable to start but I have implemented proper warnings and error message to warn the users. It is also documented in the official documentation.

**Issue number:** #2 

### Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist

- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [x] Changes are documented
- [x] Changes generate *no new warnings*
- [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

If this is a breaking change 👇

- [ ] I have documented the migration process
- [ ] I have implemented necessary warnings (if it can live side by side)

## Acknowledgement

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer:** We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
