### PR TITLE
feat: add support for alert grouping

### DIFF
--- a/src/actions/custom.ts
+++ b/src/actions/custom.ts
@@ -1,6 +1,7 @@
 import { createTemplateAction } from '@backstage/plugin-scaffolder-node';
 import { z } from 'zod';
 import * as api from '../apis/pagerduty';
+import { CreateServiceResponse } from '../types';
 
 export const createPagerDutyServiceAction = () => {
 
@@ -28,15 +29,20 @@ export const createPagerDutyServiceAction = () => {
         async handler(ctx) {
             try {
                 // Create service in PagerDuty
-                const [serviceId, serviceUrl] = await api.createService(ctx.input.name, ctx.input.description, ctx.input.escalationPolicyId, ctx.input.alertGrouping);
+                const service: CreateServiceResponse = await api.createService(
+                        ctx.input.name, 
+                        ctx.input.description, 
+                        ctx.input.escalationPolicyId, 
+                        ctx.input.alertGrouping);
                 ctx.logger.info(`Service '${ctx.input.name}' created successfully!`);
+                ctx.logger.info(`Alert grouping set to '${service.alertGrouping}'`);
 
-                ctx.output('serviceUrl', serviceUrl);
-                ctx.output('serviceId', serviceId);
+                ctx.output('serviceUrl', service.url);
+                ctx.output('serviceId', service.id);
 
                 // Create Backstage Integration in PagerDuty service
                 const backstageIntegrationId = 'PRO19CT'; // ID for Backstage integration
-                const integrationKey = await api.createServiceIntegration(serviceId, backstageIntegrationId);
+                const integrationKey = await api.createServiceIntegration(service.id, backstageIntegrationId);
                 ctx.logger.info(`Backstage Integration for service '${ctx.input.name}' created successfully!`);
 
                 ctx.output('integrationKey', integrationKey);

--- a/src/actions/custom.ts
+++ b/src/actions/custom.ts
@@ -8,6 +8,7 @@ export const createPagerDutyServiceAction = () => {
         name: string;
         description: string;
         escalationPolicyId: string;
+        alertGrouping?: string;
     }>({
         id: 'pagerduty:service:create',
         schema: {
@@ -15,6 +16,7 @@ export const createPagerDutyServiceAction = () => {
                 name: z.string().min(1, "name is required").describe('Name of the service'),
                 description: z.string().min(1, "description is required").describe('Description of the service'),
                 escalationPolicyId: z.string().min(1, "Escalation policy is required").describe('Escalation policy ID'),
+                alertGrouping: z.string().optional().describe('Alert grouping parameters'),
             }),
             output: z.object({
                 serviceUrl: z.string().describe('PagerDuty Service URL'),
@@ -26,7 +28,7 @@ export const createPagerDutyServiceAction = () => {
         async handler(ctx) {
             try {
                 // Create service in PagerDuty
-                const [serviceId, serviceUrl] = await api.createService(ctx.input.name, ctx.input.description, ctx.input.escalationPolicyId);
+                const [serviceId, serviceUrl] = await api.createService(ctx.input.name, ctx.input.description, ctx.input.escalationPolicyId, ctx.input.alertGrouping);
                 ctx.logger.info(`Service '${ctx.input.name}' created successfully!`);
 
                 ctx.output('serviceUrl', serviceUrl);

--- a/src/apis/pagerduty.test.ts
+++ b/src/apis/pagerduty.test.ts
@@ -8,20 +8,98 @@ describe("PagerDuty API", () => {
     });
 
     describe("createService", () => {
-        it("should create a service", async () => {
+        it("should create a service without event grouping when AIOps is not available", async () => {
             const name = "TestService";
             const description = "Test Service Description";
             const escalationPolicyId = "12345";
 
-            const expectedResponse = ["S3RV1CE1D", "https://testaccount.pagerduty.com/services/S3RV1CE1D"];
+            const expectedResponse = { "alertGrouping": "null", "id": "S3RV1CE1D", "url": "https://testaccount.pagerduty.com/services/S3RV1CE1D" };
 
-            global.fetch = jest.fn(() =>
+            global.fetch = jest.fn().mockReturnValueOnce(
+                Promise.resolve({
+                    status: 200,
+                    json: () => Promise.resolve({
+                        abilities: [
+                        ]
+                    })
+                })
+            ).mockReturnValueOnce(
                 Promise.resolve({
                     status: 201,
                     json: () => Promise.resolve({
                         service: {
-                            id: expectedResponse[0],
-                            htmlUrl: expectedResponse[1],
+                            id: "S3RV1CE1D",
+                            htmlUrl: "https://testaccount.pagerduty.com/services/S3RV1CE1D",
+                        }
+                    })
+                })
+            ) as jest.Mock;
+
+            const result = await createService(name, description, escalationPolicyId, "intelligent");
+
+            expect(result).toEqual(expectedResponse);
+            expect(fetch).toHaveBeenCalledTimes(2);
+        });
+
+        it("should create a service without event grouping when grouping is 'null'", async () => {
+            const name = "TestService";
+            const description = "Test Service Description";
+            const escalationPolicyId = "12345";
+
+            const expectedResponse = { "alertGrouping": "null", "id": "S3RV1CE1D", "url": "https://testaccount.pagerduty.com/services/S3RV1CE1D" };
+
+            global.fetch = jest.fn().mockReturnValueOnce(
+                Promise.resolve({
+                    status: 200,
+                    json: () => Promise.resolve({
+                        abilities: [
+                            "preview_intelligent_alert_grouping",
+                            "time_based_alert_grouping"
+                        ]
+                    })
+                })
+            ).mockReturnValueOnce(
+                Promise.resolve({
+                    status: 201,
+                    json: () => Promise.resolve({
+                        service: {
+                            id: "S3RV1CE1D",
+                            htmlUrl: "https://testaccount.pagerduty.com/services/S3RV1CE1D",
+                        }
+                    })
+                })
+            ) as jest.Mock;
+
+            const result = await createService(name, description, escalationPolicyId, "null");
+
+            expect(result).toEqual(expectedResponse);
+            expect(fetch).toHaveBeenCalledTimes(2);
+        });
+
+        it("should create a service without event grouping when grouping is undefined", async () => {
+            const name = "TestService";
+            const description = "Test Service Description";
+            const escalationPolicyId = "12345";
+
+            const expectedResponse = { "alertGrouping": "null", "id": "S3RV1CE1D", "url": "https://testaccount.pagerduty.com/services/S3RV1CE1D" };
+
+            global.fetch = jest.fn().mockReturnValueOnce(
+                Promise.resolve({
+                    status: 200,
+                    json: () => Promise.resolve({
+                        abilities: [
+                            "preview_intelligent_alert_grouping",
+                            "time_based_alert_grouping"
+                        ]
+                    })
+                })
+            ).mockReturnValueOnce(
+                Promise.resolve({
+                    status: 201,
+                    json: () => Promise.resolve({
+                        service: {
+                            id: "S3RV1CE1D",
+                            htmlUrl: "https://testaccount.pagerduty.com/services/S3RV1CE1D",
                         }
                     })
                 })
@@ -30,7 +108,42 @@ describe("PagerDuty API", () => {
             const result = await createService(name, description, escalationPolicyId);
 
             expect(result).toEqual(expectedResponse);
-            expect(fetch).toHaveBeenCalledTimes(1);
+            expect(fetch).toHaveBeenCalledTimes(2);
+        });
+
+        it("should create a service", async () => {
+            const name = "TestService";
+            const description = "Test Service Description";
+            const escalationPolicyId = "12345";
+
+            const expectedResponse = { "alertGrouping": "null", "id": "S3RV1CE1D", "url": "https://testaccount.pagerduty.com/services/S3RV1CE1D" };
+
+            global.fetch = jest.fn().mockReturnValueOnce(
+                Promise.resolve({
+                    status: 200,
+                    json: () => Promise.resolve({
+                        abilities: [
+                            "preview_intelligent_alert_grouping",
+                            "time_based_alert_grouping"
+                        ]
+                    })
+                })
+            ).mockReturnValueOnce(
+                Promise.resolve({
+                    status: 201,
+                    json: () => Promise.resolve({
+                        service: {
+                            id: "S3RV1CE1D",
+                            htmlUrl: "https://testaccount.pagerduty.com/services/S3RV1CE1D",
+                        }
+                    })
+                })
+            ) as jest.Mock;
+
+            const result = await createService(name, description, escalationPolicyId);
+
+            expect(result).toEqual(expectedResponse);
+            expect(fetch).toHaveBeenCalledTimes(2);
         });
 
         it("should NOT create a service when caller provides invalid arguments", async () => {
@@ -38,7 +151,17 @@ describe("PagerDuty API", () => {
             const description = "Test Service Description";
             const escalationPolicyId = "";
 
-            global.fetch = jest.fn(() =>
+            global.fetch = jest.fn().mockReturnValueOnce(
+                Promise.resolve({
+                    status: 200,
+                    json: () => Promise.resolve({
+                        abilities: [
+                            "preview_intelligent_alert_grouping",
+                            "time_based_alert_grouping"
+                        ]
+                    })
+                })
+            ).mockReturnValueOnce(
                 Promise.resolve({
                     status: 400,
                     json: () => Promise.resolve({})
@@ -57,7 +180,17 @@ describe("PagerDuty API", () => {
             const description = "Test Service Description";
             const escalationPolicyId = "";
 
-            global.fetch = jest.fn(() =>
+            global.fetch = jest.fn().mockReturnValueOnce(
+                Promise.resolve({
+                    status: 200,
+                    json: () => Promise.resolve({
+                        abilities: [
+                            "preview_intelligent_alert_grouping",
+                            "time_based_alert_grouping"
+                        ]
+                    })
+                })
+            ).mockReturnValueOnce(
                 Promise.resolve({
                     status: 401,
                     json: () => Promise.resolve({})
@@ -76,7 +209,17 @@ describe("PagerDuty API", () => {
             const description = "Test Service Description";
             const escalationPolicyId = "12345";
 
-            global.fetch = jest.fn(() =>
+            global.fetch = jest.fn().mockReturnValueOnce(
+                Promise.resolve({
+                    status: 200,
+                    json: () => Promise.resolve({
+                        abilities: [
+                            "preview_intelligent_alert_grouping",
+                            "time_based_alert_grouping"
+                        ]
+                    })
+                })
+            ).mockReturnValueOnce(
                 Promise.resolve({
                     status: 402,
                     json: () => Promise.resolve({})
@@ -95,7 +238,17 @@ describe("PagerDuty API", () => {
             const description = "Test Service Description";
             const escalationPolicyId = "12345";
 
-            global.fetch = jest.fn(() =>
+            global.fetch = jest.fn().mockReturnValueOnce(
+                Promise.resolve({
+                    status: 200,
+                    json: () => Promise.resolve({
+                        abilities: [
+                            "preview_intelligent_alert_grouping",
+                            "time_based_alert_grouping"
+                        ]
+                    })
+                })
+            ).mockReturnValueOnce(
                 Promise.resolve({
                     status: 403,
                     json: () => Promise.resolve({})

--- a/src/apis/pagerduty.ts
+++ b/src/apis/pagerduty.ts
@@ -2,7 +2,7 @@ import { PagerDutyCreateIntegrationResponse, PagerDutyCreateServiceResponse, Pag
 
 // Supporting custom actions
 
-export async function createService(name: string, description: string, escalationPolicyId: string): Promise<[string, string]> {    
+export async function createService(name: string, description: string, escalationPolicyId: string, alertGrouping? : string): Promise<[string, string]> {    
     let response: Response;
     const baseUrl = 'https://api.pagerduty.com/services';
     const options: RequestInit = {
@@ -14,6 +14,8 @@ export async function createService(name: string, description: string, escalatio
                 id: escalationPolicyId,
                 type: 'escalation_policy_reference',
             },
+            alert_creation: 'create_alerts_and_incidents',
+            alert_grouping_parameters: alertGrouping,
         }),
         headers: {
             Authorization: `Token token=${process.env.PAGERDUTY_TOKEN}`, 

--- a/src/apis/pagerduty.ts
+++ b/src/apis/pagerduty.ts
@@ -1,24 +1,119 @@
-import { PagerDutyCreateIntegrationResponse, PagerDutyCreateServiceResponse, PagerDutyEscalationPolicyListResponse, PagerDutyEscalationPolicy, HttpError } from "../types";
+import { PagerDutyCreateIntegrationResponse, PagerDutyCreateServiceResponse, PagerDutyEscalationPolicyListResponse, PagerDutyEscalationPolicy, HttpError, PagerDutyAbilitiesListResponse, CreateServiceResponse } from "../types";
 
 // Supporting custom actions
 
-export async function createService(name: string, description: string, escalationPolicyId: string, alertGrouping? : string): Promise<[string, string]> {    
+export async function createService(name: string, description: string, escalationPolicyId: string, alertGrouping?: string): Promise<CreateServiceResponse> {
+    let alertGroupingParameters = "null";
     let response: Response;
     const baseUrl = 'https://api.pagerduty.com/services';
-    const options: RequestInit = {
-        method: 'POST',
-        body: JSON.stringify({
+
+    // Set default body
+    let body = JSON.stringify({
+        service: {
+            type: 'service',
             name: name,
             description: description,
+            alert_creation: 'create_alerts_and_incidents',
+            auto_pause_notifications_parameters: {
+                enabled: true,
+                timeout: 300,
+            },
             escalation_policy: {
                 id: escalationPolicyId,
                 type: 'escalation_policy_reference',
             },
-            alert_creation: 'create_alerts_and_incidents',
-            alert_grouping_parameters: alertGrouping,
-        }),
+        },
+    });
+
+    // Override body if alert grouping is enabled and passed as parameter
+    if (await isEventNoiseReductionEnabled() && alertGrouping !== undefined) {
+        alertGroupingParameters = alertGrouping;
+
+        switch (alertGroupingParameters) {
+            case "intelligent":
+                body = JSON.stringify({
+                    service: {
+                        type: 'service',
+                        name: name,
+                        description: description,
+                        escalation_policy: {
+                            id: escalationPolicyId,
+                            type: 'escalation_policy_reference',
+                        },
+                        alert_creation: 'create_alerts_and_incidents',
+                        alert_grouping_parameters: {
+                            type: alertGroupingParameters,
+                        },
+                        auto_pause_notifications_parameters: {
+                            enabled: true,
+                            timeout: 300,
+                        },
+                    },
+                });
+                break;
+            case "time":
+                body = JSON.stringify({
+                    service: {
+                        type: 'service',
+                        name: name,
+                        description: description,
+                        escalation_policy: {
+                            id: escalationPolicyId,
+                            type: 'escalation_policy_reference',
+                        },
+                        alert_creation: 'create_alerts_and_incidents',
+                        alert_grouping_parameters: {
+                            type: alertGroupingParameters,
+                            config: {
+                                timeout: 0,
+                            },
+                        },
+                        auto_pause_notifications_parameters: {
+                            enabled: true,
+                            timeout: 300,
+                        },
+                    },
+                });
+                break;
+            case "content_based":
+                body = JSON.stringify({
+                    service: {
+                        type: 'service',
+                        name: name,
+                        description: description,
+                        escalation_policy: {
+                            id: escalationPolicyId,
+                            type: 'escalation_policy_reference',
+                        },
+                        alert_creation: 'create_alerts_and_incidents',
+                        alert_grouping_parameters: {
+                            type: alertGroupingParameters,
+                            config: {
+                                aggregate: 'all',
+                                time_window: 0,
+                                fields: [
+                                    'source',
+                                    'summary',
+                                ],
+                            },
+                        },
+                        auto_pause_notifications_parameters: {
+                            enabled: true,
+                            timeout: 300,
+                        },
+                    },
+                });
+                break;
+            default:
+                break;
+        }
+    }
+
+    const options: RequestInit = {
+        method: 'POST',
+        body: body,
         headers: {
-            Authorization: `Token token=${process.env.PAGERDUTY_TOKEN}`, 
+            Authorization: `Token token=${process.env.PAGERDUTY_TOKEN}`,
             'Accept': 'application/vnd.pagerduty+json;version=2',
             'Content-Type': 'application/json',
         },
@@ -47,7 +142,14 @@ export async function createService(name: string, description: string, escalatio
     try {
         result = await response.json();
 
-        return [result.service.id, result.service.htmlUrl];
+        const createServiceResult: CreateServiceResponse = {
+            url: result.service.htmlUrl,
+            id: result.service.id,
+            alertGrouping: alertGroupingParameters,
+        };
+
+        return createServiceResult;
+
     } catch (error) {
         throw new Error(`Failed to parse service information: ${error}`);
     }
@@ -146,7 +248,7 @@ async function getEscalationPolicies(offset: number, limit: number): Promise<[Bo
         result = await response.json();
 
         return [result.more, result.escalation_policies];
-        
+
     } catch (error) {
         throw new HttpError(`Failed to parse escalation policy information: ${error}`, 500);
     }
@@ -156,17 +258,62 @@ export async function getAllEscalationPolicies(offset: number = 0): Promise<Page
     const limit = 50;
 
     try {
-        const res = await getEscalationPolicies(offset, limit);        
+        const res = await getEscalationPolicies(offset, limit);
         const results = res[1];
 
         // if more results exist
         if (res[0]) {
             return results.concat((await getAllEscalationPolicies(offset + limit)));
         }
-        
+
         return results;
     } catch (error) {
-        
-        throw new HttpError(`${((error as HttpError).message) }`, ((error as HttpError).status));
+
+        throw new HttpError(`${((error as HttpError).message)}`, ((error as HttpError).status));
+    }
+}
+
+export async function isEventNoiseReductionEnabled(): Promise<boolean> {
+    let response: Response;
+    const baseUrl = 'https://api.pagerduty.com';
+    const options: RequestInit = {
+        method: 'GET',
+        headers: {
+            Authorization: `Token token=${process.env.PAGERDUTY_TOKEN}`,
+            'Accept': 'application/vnd.pagerduty+json;version=2',
+            'Content-Type': 'application/json',
+        },
+    };
+
+    try {
+        response = await fetch(`${baseUrl}/abilities`, options);
+    } catch (error) {
+        throw new Error(`Failed to read abilities: ${error}`);
+    }
+
+    switch (response.status) {
+        case 401:
+            throw new Error(`Failed to read abilities. Caller did not supply credentials or did not provide the correct credentials.`);
+        case 403:
+            throw new Error(`Failed to read abilities. Caller is not authorized to view the requested resource.`);
+        case 429:
+            throw new Error(`Failed to read abilities. Rate limit exceeded.`);
+        default: // 200
+            break;
+    }
+
+    let result: PagerDutyAbilitiesListResponse;
+    try {
+        result = await response.json();
+
+        if (result.abilities.includes('preview_intelligent_alert_grouping')
+            && result.abilities.includes('time_based_alert_grouping')) {
+            return true;
+        }
+
+        return false;
+
+    } catch (error) {
+        throw new Error(`Failed to parse abilities information: ${error}`);
     }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -95,4 +95,13 @@ export class HttpError extends Error {
     status: number;
 }
 
+export type PagerDutyAbilitiesListResponse = {
+    abilities: string[];
+};
 
+
+export type CreateServiceResponse = {
+    id: string;
+    url: string;
+    alertGrouping: string;
+};


### PR DESCRIPTION
### Description

This PR introduces the capacity to enable noise reduction through alert grouping and auto pause of notifications. 

The user will be able to pass an optional parameter (intelligent, time, content_based) from within a software template and during service creation alert grouping will be enabled automatically and using recommended defaults.

Auto pause of notifications will also be enabled by default. 

**Issue number:** #8 

### Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist

- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [x] Changes are documented
- [x] Changes generate *no new warnings*
- [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

If this is a breaking change 👇

- [ ] I have documented the migration process
- [ ] I have implemented necessary warnings (if it can live side by side)

## Acknowledgement

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer:** We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
