### PR TITLE
refactor: improve http error handling in REST API endpoints

### DIFF
--- a/src/service/router.test.ts
+++ b/src/service/router.test.ts
@@ -323,7 +323,7 @@ describe('createRouter', () => {
         ) as jest.Mock;
 
         const expectedStatusCode = 404;
-        const expectedResponse = "Failed to get service. The requested resource was not found.";
+        const expectedResponse = { "errors": ["Failed to get service. The requested resource was not found."] };
 
         const response = await request(app).get(`/services?integration_key=${integrationKey}`);
 
@@ -417,7 +417,7 @@ describe('createRouter', () => {
         ) as jest.Mock;
 
         const expectedStatusCode = 404;
-        const expectedResponse = "Failed to get service. The requested resource was not found.";
+        const expectedResponse = {"errors": ["Failed to get service. The requested resource was not found."]};
 
         const response = await request(app).get(`/services/${serviceId}`);
 
@@ -527,7 +527,7 @@ describe('createRouter', () => {
         ) as jest.Mock;
 
         const expectedStatusCode = 404;
-        const expectedResponse = "Failed to get change events for service. The requested resource was not found.";
+        const expectedResponse = { "errors": ["Failed to get change events for service. The requested resource was not found."] };
 
         const response = await request(app).get(`/services/${serviceId}/change-events`);
 

--- a/src/service/router.ts
+++ b/src/service/router.ts
@@ -45,7 +45,11 @@ export async function createRouter(
             response.json(escalationPolicyDropDownOptions);
         } catch (error) {
             if (error instanceof HttpError) {
-                response.status(error.status).json(`${error.message}`);
+                response.status(error.status).json({
+                    errors: [
+                        `${error.message}`
+                    ]
+                });
             }
         }
     });
@@ -68,7 +72,11 @@ export async function createRouter(
             response.json(onCallUsersResponse);
         } catch (error) {
             if (error instanceof HttpError) {
-                response.status(error.status).json(`${error.message}`);
+                response.status(error.status).json({
+                    errors: [
+                        `${error.message}`
+                    ]
+                });
             }
         }
     });
@@ -91,7 +99,11 @@ export async function createRouter(
             response.json(serviceResponse);
         } catch (error) {
             if (error instanceof HttpError) {
-                response.status(error.status).json(`${error.message}`);
+                response.status(error.status).json({
+                    errors: [
+                        `${error.message}`
+                    ]
+                });
             }
         }
     });
@@ -114,7 +126,11 @@ export async function createRouter(
             response.json(serviceResponse);
         } catch (error) {
             if (error instanceof HttpError) {
-                response.status(error.status).json(`${error.message}`);
+                response.status(error.status).json({
+                    errors: [
+                        `${error.message}`
+                    ]
+                });
             }
         }
     });
@@ -133,7 +149,11 @@ export async function createRouter(
             response.json(changeEventsResponse);
         } catch (error) {
             if (error instanceof HttpError) {
-                response.status(error.status).json(`${error.message}`);
+                response.status(error.status).json({
+                    errors: [
+                        `${error.message}`
+                    ]
+                });
             }
         }
     });
@@ -152,7 +172,11 @@ export async function createRouter(
             response.json(incidentsResponse);
         } catch (error) {
             if (error instanceof HttpError) {
-                response.status(error.status).json(`${error.message}`);
+                response.status(error.status).json({
+                    errors: [
+                        `${error.message}`
+                    ]
+                });
             }
         }
     });


### PR DESCRIPTION
### Description

Refactor HTTP error handling in REST API endpoints for backend routes. The new payload expected when an HTTP error is captured looks like the following. 

```json
{
    "errors": [
        "Failed to get change events for service. Caller is not authorized to view the requested resource."
    ]
}
```

This helps in providing a better user experience to the user from a frontend perspective.

**Issue number:** N/A

### Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist

- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [x] Changes are documented
- [x] Changes generate *no new warnings*
- [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

If this is a breaking change 👇

- [ ] I have documented the migration process
- [ ] I have implemented necessary warnings (if it can live side by side)

## Acknowledgement

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer:** We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
