### PR TITLE
refactor: change start behavior on missing credentials

### DIFF
--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -43,12 +43,10 @@ export async function loadAuthConfig(logger: Logger, config: Config) {
             if (!config.getOptional('pagerDuty.oauth')) {
                 
                 logger.error('No PagerDuty OAuth configuration found in config file.');
-                throw new Error("No PagerDuty 'apiToken' or 'oauth' configuration found in config file.");
 
             } else if (!config.getOptionalString('pagerDuty.oauth.clientId') || !config.getOptionalString('pagerDuty.oauth.clientSecret') || !config.getOptionalString('pagerDuty.oauth.subDomain')) {
                 
                 logger.error("Missing required PagerDuty OAuth parameters in config file. 'clientId', 'clientSecret', and 'subDomain' are required. 'region' is optional.");
-                throw new Error('Missing required PagerDuty OAuth parameters in config file.');
 
             } else {
 
@@ -68,7 +66,6 @@ export async function loadAuthConfig(logger: Logger, config: Config) {
     }
     catch (error) {
         logger.error(`Unable to retrieve valid PagerDuty AUTH configuration from config file: ${error}`);
-        throw error;
     }
 }
 


### PR DESCRIPTION
### Description

This PR changes the start behaviour for the plugin by logging the error but still allowing the plugin to start. This change allows us to match what other Backstage plugins do. 

**Issue number:** #26 

### Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist

- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [ ] Changes are documented
- [x] Changes generate *no new warnings*
- [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

If this is a breaking change 👇

- [ ] I have documented the migration process
- [ ] I have implemented necessary warnings (if it can live side by side)

## Acknowledgement

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer:** We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
