### PR TITLE
release: 0.4.3

### DIFF
--- a/config.d.ts
+++ b/config.d.ts
@@ -28,6 +28,11 @@ export interface Config {
          */
         eventsBaseUrl?: string;
         /**
+         * Optional API Base URL to override the default.
+         * @visibility frontend
+         */
+        apiBaseUrl?: string;
+        /**
          * Optional PagerDuty API Token used in API calls from the backend component.
          * @visibility frontend
          */

--- a/src/apis/pagerduty.ts
+++ b/src/apis/pagerduty.ts
@@ -20,11 +20,16 @@ import {
     HttpError
 } from '@pagerduty/backstage-plugin-common';
 
+let apiBaseUrl = 'https://api.pagerduty.com';
+export function setAPIBaseUrl(url: string): void {
+    apiBaseUrl = url;
+}
+
 // Supporting custom actions
 export async function createService(name: string, description: string, escalationPolicyId: string, alertGrouping?: string): Promise<CreateServiceResponse> {
     let alertGroupingParameters = "null";
     let response: Response;
-    const baseUrl = 'https://api.pagerduty.com/services';
+    const baseUrl = `${apiBaseUrl}/services`;
 
     // Set default body
     let body = JSON.stringify({
@@ -176,7 +181,7 @@ export async function createService(name: string, description: string, escalatio
 
 export async function createServiceIntegration(serviceId: string, vendorId: string): Promise<string> {
     let response: Response;
-    const baseUrl = 'https://api.pagerduty.com/services';
+    const baseUrl = `${apiBaseUrl}/services`;
     const options: RequestInit = {
         method: 'POST',
         body: JSON.stringify({
@@ -242,7 +247,7 @@ async function getEscalationPolicies(offset: number, limit: number): Promise<[Bo
             'Content-Type': 'application/json',
         },
     };
-    const baseUrl = 'https://api.pagerduty.com/escalation_policies';
+    const baseUrl = `${apiBaseUrl}/escalation_policies`;
 
     try {
         response = await fetch(`${baseUrl}?${params}`, options);
@@ -353,7 +358,7 @@ export async function getOncallUsers(escalationPolicy: string): Promise<PagerDut
             'Content-Type': 'application/json',
         },
     };
-    const baseUrl = 'https://api.pagerduty.com/oncalls';
+    const baseUrl = `${apiBaseUrl}/oncalls`;
 
     try {
         response = await fetch(`${baseUrl}?${params}`, options);
@@ -425,7 +430,7 @@ export async function getServiceById(serviceId: string): Promise<PagerDutyServic
             'Content-Type': 'application/json',
         },
     };
-    const baseUrl = 'https://api.pagerduty.com/services';
+    const baseUrl = `${apiBaseUrl}/services`;
 
     try {
         response = await fetch(`${baseUrl}/${serviceId}?${params}`, options);
@@ -467,7 +472,7 @@ export async function getServiceByIntegrationKey(integrationKey: string): Promis
             'Content-Type': 'application/json',
         },
     };
-    const baseUrl = 'https://api.pagerduty.com/services';
+    const baseUrl = `${apiBaseUrl}/services`;
 
     try {
         response = await fetch(`${baseUrl}?${params}`, options);
@@ -513,7 +518,7 @@ export async function getChangeEvents(serviceId: string): Promise<PagerDutyChang
             'Content-Type': 'application/json',
         },
     };
-    const baseUrl = 'https://api.pagerduty.com/services';
+    const baseUrl = `${apiBaseUrl}/services`;
 
     try {
         response = await fetch(`${baseUrl}/${serviceId}/change_events?${params}`, options);
@@ -556,7 +561,7 @@ export async function getIncidents(serviceId: string): Promise<PagerDutyIncident
             'Content-Type': 'application/json',
         },
     };
-    const baseUrl = 'https://api.pagerduty.com/incidents';
+    const baseUrl = `${apiBaseUrl}/incidents`;
 
     try {
         response = await fetch(`${baseUrl}?${params}`, options);

--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -43,12 +43,10 @@ export async function loadAuthConfig(logger: Logger, config: Config) {
             if (!config.getOptional('pagerDuty.oauth')) {
                 
                 logger.error('No PagerDuty OAuth configuration found in config file.');
-                throw new Error("No PagerDuty 'apiToken' or 'oauth' configuration found in config file.");
 
             } else if (!config.getOptionalString('pagerDuty.oauth.clientId') || !config.getOptionalString('pagerDuty.oauth.clientSecret') || !config.getOptionalString('pagerDuty.oauth.subDomain')) {
                 
                 logger.error("Missing required PagerDuty OAuth parameters in config file. 'clientId', 'clientSecret', and 'subDomain' are required. 'region' is optional.");
-                throw new Error('Missing required PagerDuty OAuth parameters in config file.');
 
             } else {
 
@@ -68,7 +66,6 @@ export async function loadAuthConfig(logger: Logger, config: Config) {
     }
     catch (error) {
         logger.error(`Unable to retrieve valid PagerDuty AUTH configuration from config file: ${error}`);
-        throw error;
     }
 }
 

--- a/src/service/router.ts
+++ b/src/service/router.ts
@@ -3,7 +3,7 @@ import { Config } from '@backstage/config';
 import express from 'express';
 import Router from 'express-promise-router';
 import { Logger } from 'winston';
-import { getAllEscalationPolicies, getChangeEvents, getIncidents, getOncallUsers, getServiceById, getServiceByIntegrationKey } from '../apis/pagerduty';
+import { getAllEscalationPolicies, getChangeEvents, getIncidents, getOncallUsers, getServiceById, getServiceByIntegrationKey, setAPIBaseUrl } from '../apis/pagerduty';
 import { HttpError, PagerDutyChangeEventsResponse, PagerDutyIncidentsResponse, PagerDutyOnCallUsersResponse, PagerDutyServiceResponse } from '@pagerduty/backstage-plugin-common';
 import { loadAuthConfig } from '../auth/auth';
 
@@ -20,8 +20,12 @@ export async function createRouter(
     // Get authentication Config
     await loadAuthConfig(logger, config);
 
+    // Get the PagerDuty API Base URL from config
+    const baseUrl = config.getOptionalString('pagerDuty.apiBaseUrl') !== undefined ? config.getString('pagerDuty.apiBaseUrl') : 'https://api.pagerduty.com';
+    setAPIBaseUrl(baseUrl);
+
     // Create the router
-    const router = Router();
+    const router = Router();    
     router.use(express.json());
 
     // Add routes


### PR DESCRIPTION
### Description

This release resolves an issue reported in backstage-plugin ([#74](https://github.com/PagerDuty/backstage-plugin/issues/74)) which prevents users from overriding the REST API base url (e.g. for EU based accounts). This feature was possible through the Backstage proxy configuration.

With this, users will be able to add a new configuration to the PagerDuty plugin in `app-config.yaml` like the example below. 

```yaml
pagerDuty:
  apiBaseUrl: https://api.eu.pagerduty.com     #defaults to https://api.pagerduty.com
```

## Acknowledgement

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer:** We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
