### PR TITLE
fix: ensure secret configuration values are secret

### DIFF
--- a/config.d.ts
+++ b/config.d.ts
@@ -34,12 +34,12 @@ export interface Config {
         apiBaseUrl?: string;
         /**
          * Optional PagerDuty API Token used in API calls from the backend component.
-         * @visibility frontend
+         * @visibility secret
          */
         apiToken?: string;
         /**
          * Optional PagerDuty Scoped OAuth Token used in API calls from the backend component.
-         * @visibility frontend
+         * @deepVisibility secret
          */
         oauth?: PagerDutyOAuthConfig;
     };


### PR DESCRIPTION
### Description

Updates the `config.d.ts` values to mark `pagerDuty.apiToken` and `pagerDuty.oauth` as secret values.

These are only used by the backend currently and should not be made visible to the frontend.

See https://backstage.io/docs/conf/defining/#visibility for more details

See related https://github.com/PagerDuty/backstage-plugin/pull/78 to remove configuration from the frontend plugin.

### Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist

- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [x] Changes are documented
- [x] Changes generate *no new warnings*
- [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

If this is a breaking change 👇

- [ ] I have documented the migration process
- [ ] I have implemented necessary warnings (if it can live side by side)

## Acknowledgement

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer:** We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
