### PR TITLE
release: 0.7.1

### DIFF
--- a/src/service/router.ts
+++ b/src/service/router.ts
@@ -25,7 +25,7 @@ export type Annotations = {
 
 export async function createComponentEntitiesReferenceDict({ items: componentEntities }: GetEntitiesResponse): Promise<Record<string, { ref: string, name: string }>> {
     const componentEntitiesDict: Record<string, { ref: string, name: string }> = {};
-    
+
     await Promise.all(componentEntities.map(async (entity) => {
         const annotations: Annotations = JSON.parse(JSON.stringify(entity.metadata.annotations));
         const serviceId = annotations['pagerduty.com/service-id'];
@@ -38,10 +38,10 @@ export async function createComponentEntitiesReferenceDict({ items: componentEnt
             };
         }
         else if (integrationKey !== undefined && integrationKey !== "") {
-            // get service id from integration key  
+            // get service id from integration key
             const service : PagerDutyService = await getServiceByIntegrationKey(integrationKey);
 
-            if (service !== undefined) {                
+            if (service !== undefined) {
                 componentEntitiesDict[service.id] = {
                     ref: `${entity.kind}:${entity.metadata.namespace}/${entity.metadata.name}`.toLowerCase(),
                     name: entity.metadata.name,
@@ -54,11 +54,11 @@ export async function createComponentEntitiesReferenceDict({ items: componentEnt
 }
 
 export async function buildEntityMappingsResponse(
-    entityMappings: RawDbEntityResultRow[], 
+    entityMappings: RawDbEntityResultRow[],
     componentEntitiesDict: Record<string, {
         ref: string;
         name: string;
-    }>, 
+    }>,
     componentEntities: GetEntitiesResponse,
     pagerDutyServices: PagerDutyService[]
     ) : Promise<PagerDutyEntityMappingsResponse> {
@@ -66,7 +66,7 @@ export async function buildEntityMappingsResponse(
     const result: PagerDutyEntityMappingsResponse = {
         mappings: []
     };
-    
+
     pagerDutyServices.forEach((service) => {
         // Check for service mapping annotation in any entity config file and get the entity ref
         const entityRef = componentEntitiesDict[service.id]?.ref;
@@ -85,7 +85,7 @@ export async function buildEntityMappingsResponse(
                         serviceId: entityMapping.serviceId,
                         status: "NotMapped",
                         serviceName: service.name,
-                        team: service.teams !== undefined ? service.teams[0].name : "",
+                        team: service.teams?.[0]?.name ?? "",
                         escalationPolicy: service.escalation_policy !== undefined ? service.escalation_policy.name : "",
                         serviceUrl: service.html_url,
                     });
@@ -100,7 +100,7 @@ export async function buildEntityMappingsResponse(
                         integrationKey: entityMapping.integrationKey,
                         status: "OutOfSync",
                         serviceName: service.name,
-                        team: service.teams !== undefined ? service.teams[0].name : "",
+                        team: service.teams?.[0]?.name ?? "",
                         escalationPolicy: service.escalation_policy !== undefined ? service.escalation_policy.name : "",
                         serviceUrl: service.html_url,
                     });
@@ -115,7 +115,7 @@ export async function buildEntityMappingsResponse(
                     integrationKey: entityMapping.integrationKey,
                     status: "OutOfSync",
                     serviceName: service.name,
-                    team: service.teams !== undefined ? service.teams[0].name : "",
+                    team: service.teams?.[0]?.name ?? "",
                     escalationPolicy: service.escalation_policy !== undefined ? service.escalation_policy.name : "",
                     serviceUrl: service.html_url,
                 });
@@ -127,7 +127,7 @@ export async function buildEntityMappingsResponse(
                     integrationKey: entityMapping.integrationKey,
                     status: "InSync",
                     serviceName: service.name,
-                    team: service.teams !== undefined ? service.teams[0].name : "",
+                    team: service.teams?.[0]?.name ?? "",
                     escalationPolicy: service.escalation_policy !== undefined ? service.escalation_policy.name : "",
                     serviceUrl: service.html_url,
                 });
@@ -144,7 +144,7 @@ export async function buildEntityMappingsResponse(
                     integrationKey: backstageIntegrationKey,
                     status: "InSync",
                     serviceName: service.name,
-                    team: service.teams !== undefined ? service.teams[0].name : "",
+                    team: service.teams?.[0]?.name ?? "",
                     escalationPolicy: service.escalation_policy !== undefined ? service.escalation_policy.name : "",
                     serviceUrl: service.html_url,
                 });
@@ -156,7 +156,7 @@ export async function buildEntityMappingsResponse(
                     integrationKey: backstageIntegrationKey,
                     status: "NotMapped",
                     serviceName: service.name,
-                    team: service.teams !== undefined ? service.teams[0].name : "",
+                    team: service.teams?.[0]?.name ?? "",
                     escalationPolicy: service.escalation_policy !== undefined ? service.escalation_policy.name : "",
                     serviceUrl: service.html_url,
                 });
@@ -219,7 +219,7 @@ export async function createRouter(
             }
 
             if (oldMapping && oldMapping.entityRef !== "") {
-                // force refresh of old entity 
+                // force refresh of old entity
                 await catalogApi?.refreshEntity(oldMapping.entityRef);
             }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -944,8 +944,8 @@ __metadata:
   linkType: hard
 
 "@azure/identity@npm:^4.0.0":
-  version: 4.2.0
-  resolution: "@azure/identity@npm:4.2.0"
+  version: 4.2.1
+  resolution: "@azure/identity@npm:4.2.1"
   dependencies:
     "@azure/abort-controller": ^1.0.0
     "@azure/core-auth": ^1.5.0
@@ -955,13 +955,13 @@ __metadata:
     "@azure/core-util": ^1.3.0
     "@azure/logger": ^1.0.0
     "@azure/msal-browser": ^3.11.1
-    "@azure/msal-node": ^2.6.6
+    "@azure/msal-node": ^2.9.2
     events: ^3.0.0
     jws: ^4.0.0
     open: ^8.0.0
     stoppable: ^1.1.0
     tslib: ^2.2.0
-  checksum: b1b336113c944abf89376f366bf8e82958617465c91e561e922c165a10aaa1789e83a78b7baa070671247d0f97c63b4cc89cf6cabc72258f3d9cbe12fe799e2a
+  checksum: 2dbd7b0fa6b92904b7b8f828374d7316384cc4e00c71cdac3a2f2544b9e02c7287fe7ad58149bb8794c57913d77a927f5a7b5d1367e05abe82b0f2e1b162415c
   languageName: node
   linkType: hard
 
@@ -975,29 +975,29 @@ __metadata:
   linkType: hard
 
 "@azure/msal-browser@npm:^3.11.1":
-  version: 3.14.0
-  resolution: "@azure/msal-browser@npm:3.14.0"
+  version: 3.17.0
+  resolution: "@azure/msal-browser@npm:3.17.0"
   dependencies:
-    "@azure/msal-common": 14.10.0
-  checksum: 747cd3df32f082e515c5e268d64f0d16afa0ce21ab5154e235ee0eb0fd0e2902504d12bac1f94839afaf9cc94c823d961775c3f57c3f20f12864d13a5ed0fa44
+    "@azure/msal-common": 14.12.0
+  checksum: 4b01ee3500e5bb1c8a71e92b81f61174d23109eb60101c17bf95ede248eeefd2ca5d68228d7d1cf147eeeade5bbe994a09f8ada96e14f3352da7822899c0c441
   languageName: node
   linkType: hard
 
-"@azure/msal-common@npm:14.10.0":
-  version: 14.10.0
-  resolution: "@azure/msal-common@npm:14.10.0"
-  checksum: 50994f54cdce7425bef42d44b3b15e756ede11efa5d2f84440da41ea13f0b0c00e8c262925e42b2f6d5f6f850233dccf99d810ced7b2cf372b9a645ed53489f8
+"@azure/msal-common@npm:14.12.0":
+  version: 14.12.0
+  resolution: "@azure/msal-common@npm:14.12.0"
+  checksum: 9a987b7b9b6453500481ec48224b4d9f728c62ac584f9a35ef519eff46016fc63c1a7dc159f725a5ec3748bf1ade352654fd7a7170ba42bc27ca263a01cf59db
   languageName: node
   linkType: hard
 
-"@azure/msal-node@npm:^2.6.6":
-  version: 2.8.1
-  resolution: "@azure/msal-node@npm:2.8.1"
+"@azure/msal-node@npm:^2.9.2":
+  version: 2.9.2
+  resolution: "@azure/msal-node@npm:2.9.2"
   dependencies:
-    "@azure/msal-common": 14.10.0
+    "@azure/msal-common": 14.12.0
     jsonwebtoken: ^9.0.0
     uuid: ^8.3.0
-  checksum: 625a0409a48c6ad20a2938d160e505c657891d37e9c698aad40670796dfa068edd1b29f626cf8b190d603d2677cdb7bc4499772a5a8deee5da9ae501c2651fa9
+  checksum: a2b51d4085d20cbac84752b9e68a5a22c7c9dbfdbc25a1713ee5e6918a504928f82e66c9317fc78db4f12053e7debd477b984cab578e0bea269aacc0862e7219
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description

PagerDuty advocates for full-service ownership and one recommendation on that direction is for customers to associate teams with services to state clear ownership of that service. Still, this is not enforced and therefore some customers don't have teams configured.

This release ensures the backend handles empty teams arrays gracefully to prevent the PagerDutyPage component from staying in a loading state indefinitely. 

## Acknowledgement

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer:** We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
