### PR TITLE
fix: ignore invalid integration keys when building entity reference dict

### DIFF
--- a/src/service/router.test.ts
+++ b/src/service/router.test.ts
@@ -999,6 +999,62 @@ describe('createRouter', () => {
         expect(result).toEqual(expectedReferenceDictionary);
       });
 
+      it("ignores invalid integration keys when building entity mapping reference", async () => {
+        mocked(fetch).mockReturnValue(mockedResponse(200, {"services": []}));
+
+        const mockEntitiesResponse = {
+          "items":
+            [
+              {
+                "metadata":
+                {
+                  "namespace": "default",
+                  "annotations":
+                  {
+                    "pagerduty.com/integration-key": "PAGERDUTY-INTEGRATION-KEY-1",
+                  },
+                  "name": "ENTITY1",
+                  "uid": "00000000-0000-4000-0000-000000000001",
+                },
+                "apiVersion": "backstage.io/v1alpha1",
+                "kind": "Component",
+                "spec":
+                {
+                  "type": "website",
+                  "lifecycle": "experimental",
+                  "owner": "OWNER1",
+                  "system": "SYSTEM1",
+                },
+                "relations":
+                  [
+                    {
+                      "type": "ownedBy",
+                      "targetRef": "group:default/OWNER1",
+                      "target":
+                        { "kind": "group", "namespace": "default", "name": "OWNER1" },
+                    },
+                    {
+                      "type": "partOf",
+                      "targetRef": "system:default/SYSTEM1",
+                      "target":
+                      {
+                        "kind": "system",
+                        "namespace": "default",
+                        "name": "SYSTEM1",
+                      },
+                    },
+                  ],
+              },
+            ],
+        };
+
+        const expectedReferenceDictionary: Record<string, { ref: string, name: string }> = {};
+
+        const result = await createComponentEntitiesReferenceDict(mockEntitiesResponse);
+
+        expect(result).toEqual(expectedReferenceDictionary);
+      });
+
       it("builds entity mapping response for with InSync status when ONLY config mapping exists", async () => {
         const mockEntityMappings: RawDbEntityResultRow[] = [];
 

--- a/src/service/router.ts
+++ b/src/service/router.ts
@@ -38,8 +38,9 @@ export async function createComponentEntitiesReferenceDict({ items: componentEnt
             };
         }
         else if (integrationKey !== undefined && integrationKey !== "") {
-            // get service id from integration key
-            const service : PagerDutyService = await getServiceByIntegrationKey(integrationKey);
+            // get service id from integration key, we ignore errors here since we're focused
+            // only on building a mapping between valid service IDs and the corresponding Backstage entity
+            const service = await getServiceByIntegrationKey(integrationKey).catch(() => undefined);
 
             if (service !== undefined) {
                 componentEntitiesDict[service.id] = {


### PR DESCRIPTION
### Description

When building the mapping between service ID and backstage entities, any invalid data in the catalog would result in an error (as reported in #68). This PR fixes #68.

**Issue number:** #68 

### Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist

- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [ ] Changes are documented
- [x] Changes generate *no new warnings*
- [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

## Acknowledgement

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer:** We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.