### PR TITLE
release: 0.7.2

### DIFF
--- a/src/service/router.test.ts
+++ b/src/service/router.test.ts
@@ -999,6 +999,62 @@ describe('createRouter', () => {
         expect(result).toEqual(expectedReferenceDictionary);
       });
 
+      it("ignores invalid integration keys when building entity mapping reference", async () => {
+        mocked(fetch).mockReturnValue(mockedResponse(200, {"services": []}));
+
+        const mockEntitiesResponse = {
+          "items":
+            [
+              {
+                "metadata":
+                {
+                  "namespace": "default",
+                  "annotations":
+                  {
+                    "pagerduty.com/integration-key": "PAGERDUTY-INTEGRATION-KEY-1",
+                  },
+                  "name": "ENTITY1",
+                  "uid": "00000000-0000-4000-0000-000000000001",
+                },
+                "apiVersion": "backstage.io/v1alpha1",
+                "kind": "Component",
+                "spec":
+                {
+                  "type": "website",
+                  "lifecycle": "experimental",
+                  "owner": "OWNER1",
+                  "system": "SYSTEM1",
+                },
+                "relations":
+                  [
+                    {
+                      "type": "ownedBy",
+                      "targetRef": "group:default/OWNER1",
+                      "target":
+                        { "kind": "group", "namespace": "default", "name": "OWNER1" },
+                    },
+                    {
+                      "type": "partOf",
+                      "targetRef": "system:default/SYSTEM1",
+                      "target":
+                      {
+                        "kind": "system",
+                        "namespace": "default",
+                        "name": "SYSTEM1",
+                      },
+                    },
+                  ],
+              },
+            ],
+        };
+
+        const expectedReferenceDictionary: Record<string, { ref: string, name: string }> = {};
+
+        const result = await createComponentEntitiesReferenceDict(mockEntitiesResponse);
+
+        expect(result).toEqual(expectedReferenceDictionary);
+      });
+
       it("builds entity mapping response for with InSync status when ONLY config mapping exists", async () => {
         const mockEntityMappings: RawDbEntityResultRow[] = [];
 

--- a/src/service/router.ts
+++ b/src/service/router.ts
@@ -38,8 +38,9 @@ export async function createComponentEntitiesReferenceDict({ items: componentEnt
             };
         }
         else if (integrationKey !== undefined && integrationKey !== "") {
-            // get service id from integration key
-            const service : PagerDutyService = await getServiceByIntegrationKey(integrationKey);
+            // get service id from integration key, we ignore errors here since we're focused
+            // only on building a mapping between valid service IDs and the corresponding Backstage entity
+            const service = await getServiceByIntegrationKey(integrationKey).catch(() => undefined);
 
             if (service !== undefined) {
                 componentEntitiesDict[service.id] = {

--- a/src/service/router.ts
+++ b/src/service/router.ts
@@ -25,7 +25,7 @@ export type Annotations = {
 
 export async function createComponentEntitiesReferenceDict({ items: componentEntities }: GetEntitiesResponse): Promise<Record<string, { ref: string, name: string }>> {
     const componentEntitiesDict: Record<string, { ref: string, name: string }> = {};
-    
+
     await Promise.all(componentEntities.map(async (entity) => {
         const annotations: Annotations = JSON.parse(JSON.stringify(entity.metadata.annotations));
         const serviceId = annotations['pagerduty.com/service-id'];
@@ -38,10 +38,10 @@ export async function createComponentEntitiesReferenceDict({ items: componentEnt
             };
         }
         else if (integrationKey !== undefined && integrationKey !== "") {
-            // get service id from integration key  
+            // get service id from integration key
             const service : PagerDutyService = await getServiceByIntegrationKey(integrationKey);
 
-            if (service !== undefined) {                
+            if (service !== undefined) {
                 componentEntitiesDict[service.id] = {
                     ref: `${entity.kind}:${entity.metadata.namespace}/${entity.metadata.name}`.toLowerCase(),
                     name: entity.metadata.name,
@@ -54,11 +54,11 @@ export async function createComponentEntitiesReferenceDict({ items: componentEnt
 }
 
 export async function buildEntityMappingsResponse(
-    entityMappings: RawDbEntityResultRow[], 
+    entityMappings: RawDbEntityResultRow[],
     componentEntitiesDict: Record<string, {
         ref: string;
         name: string;
-    }>, 
+    }>,
     componentEntities: GetEntitiesResponse,
     pagerDutyServices: PagerDutyService[]
     ) : Promise<PagerDutyEntityMappingsResponse> {
@@ -66,7 +66,7 @@ export async function buildEntityMappingsResponse(
     const result: PagerDutyEntityMappingsResponse = {
         mappings: []
     };
-    
+
     pagerDutyServices.forEach((service) => {
         // Check for service mapping annotation in any entity config file and get the entity ref
         const entityRef = componentEntitiesDict[service.id]?.ref;
@@ -85,7 +85,7 @@ export async function buildEntityMappingsResponse(
                         serviceId: entityMapping.serviceId,
                         status: "NotMapped",
                         serviceName: service.name,
-                        team: service.teams !== undefined ? service.teams[0].name : "",
+                        team: service.teams?.[0]?.name ?? "",
                         escalationPolicy: service.escalation_policy !== undefined ? service.escalation_policy.name : "",
                         serviceUrl: service.html_url,
                     });
@@ -100,7 +100,7 @@ export async function buildEntityMappingsResponse(
                         integrationKey: entityMapping.integrationKey,
                         status: "OutOfSync",
                         serviceName: service.name,
-                        team: service.teams !== undefined ? service.teams[0].name : "",
+                        team: service.teams?.[0]?.name ?? "",
                         escalationPolicy: service.escalation_policy !== undefined ? service.escalation_policy.name : "",
                         serviceUrl: service.html_url,
                     });
@@ -115,7 +115,7 @@ export async function buildEntityMappingsResponse(
                     integrationKey: entityMapping.integrationKey,
                     status: "OutOfSync",
                     serviceName: service.name,
-                    team: service.teams !== undefined ? service.teams[0].name : "",
+                    team: service.teams?.[0]?.name ?? "",
                     escalationPolicy: service.escalation_policy !== undefined ? service.escalation_policy.name : "",
                     serviceUrl: service.html_url,
                 });
@@ -127,7 +127,7 @@ export async function buildEntityMappingsResponse(
                     integrationKey: entityMapping.integrationKey,
                     status: "InSync",
                     serviceName: service.name,
-                    team: service.teams !== undefined ? service.teams[0].name : "",
+                    team: service.teams?.[0]?.name ?? "",
                     escalationPolicy: service.escalation_policy !== undefined ? service.escalation_policy.name : "",
                     serviceUrl: service.html_url,
                 });
@@ -144,7 +144,7 @@ export async function buildEntityMappingsResponse(
                     integrationKey: backstageIntegrationKey,
                     status: "InSync",
                     serviceName: service.name,
-                    team: service.teams !== undefined ? service.teams[0].name : "",
+                    team: service.teams?.[0]?.name ?? "",
                     escalationPolicy: service.escalation_policy !== undefined ? service.escalation_policy.name : "",
                     serviceUrl: service.html_url,
                 });
@@ -156,7 +156,7 @@ export async function buildEntityMappingsResponse(
                     integrationKey: backstageIntegrationKey,
                     status: "NotMapped",
                     serviceName: service.name,
-                    team: service.teams !== undefined ? service.teams[0].name : "",
+                    team: service.teams?.[0]?.name ?? "",
                     escalationPolicy: service.escalation_policy !== undefined ? service.escalation_policy.name : "",
                     serviceUrl: service.html_url,
                 });
@@ -219,7 +219,7 @@ export async function createRouter(
             }
 
             if (oldMapping && oldMapping.entityRef !== "") {
-                // force refresh of old entity 
+                // force refresh of old entity
                 await catalogApi?.refreshEntity(oldMapping.entityRef);
             }
 


### PR DESCRIPTION
### Description

This release handles properly an exception that was causing the entity mapping page to break when there is an integration key specified in the entity configuration and that integration key doesn't exist in the PagerDuty Account. 

Previously it would return an HTTP 404 error, causing the application to break. Now, it handles that error without breaking the application.

## Acknowledgement

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer:** We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
