### PR TITLE
feat: add support for multiple accounts

### DIFF
--- a/config.d.ts
+++ b/config.d.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { PagerDutyOAuthConfig } from '@pagerduty/backstage-plugin-common';
+import { PagerDutyAccountConfig, PagerDutyOAuthConfig } from '@pagerduty/backstage-plugin-common';
 
 export interface Config {
     /**
@@ -42,5 +42,10 @@ export interface Config {
          * @deepVisibility secret
          */
         oauth?: PagerDutyOAuthConfig;
+        /**
+         * Optional PagerDuty multi-account configuration
+         * @deepVisibility secret
+         */
+        accounts?: PagerDutyAccountConfig[];
     };
 }

--- a/migrations/20240710_add_account_column.js
+++ b/migrations/20240710_add_account_column.js
@@ -1,0 +1,20 @@
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function up(knex) {
+    await knex.schema.alterTable('pagerduty_entity_mapping', table => {
+        table.string('account');
+        table.dropIndex(['serviceId', 'entityRef'], 'entity_mapping_service_id_idx');
+        table.index(['serviceId', 'entityRef', 'account'], 'entity_mapping_service_id_idx');
+    });
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.down = async function down(knex) {
+    await knex.schema.alterTable('pagerduty_entity_mapping', table => {
+        table.dropColumn('account');
+        table.dropIndex([], 'entity_mapping_service_id_idx');
+    });
+};

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@backstage/plugin-catalog-node": "^1.12.0",
     "@backstage/plugin-scaffolder-node": "^0.4.4",
     "@material-ui/core": "^4.12.4",
-    "@pagerduty/backstage-plugin-common": "0.1.5",
+    "@pagerduty/backstage-plugin-common": "0.2.0",
     "@rjsf/core": "^5.14.3",
     "@types/express": "^4.17.6",
     "express": "^4.19.2",

--- a/src/apis/pagerduty.test.ts
+++ b/src/apis/pagerduty.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable jest/no-conditional-expect */
-import { HttpError, PagerDutyChangeEvent, PagerDutyIncident, PagerDutyIncidentsResponse, PagerDutyService } from "@pagerduty/backstage-plugin-common";
-import { getAllEscalationPolicies, getAllServices, getChangeEvents, getIncidents, getOncallUsers, getServiceById, getServiceByIntegrationKey, getServiceMetrics, getServiceStandards } from "./pagerduty";
+import { HttpError, PagerDutyAccountConfig, PagerDutyChangeEvent, PagerDutyIncident, PagerDutyIncidentsResponse, PagerDutyService } from "@pagerduty/backstage-plugin-common";
+import { getAllEscalationPolicies, getAllServices, getChangeEvents, getIncidents, getOncallUsers, getServiceById, getServiceByIntegrationKey, getServiceMetrics, getServiceStandards, insertEndpointConfig, setFallbackEndpointConfig } from "./pagerduty";
 
 import { mocked } from "jest-mock";
 import fetch, { Response } from "node-fetch";
@@ -25,6 +25,18 @@ function mockedResponse(status: number, body: any): Promise<Response> {
 }
 
 describe("PagerDuty API", () => {    
+    beforeAll(() => {
+
+        const mockAccount: PagerDutyAccountConfig = {
+            id: "testaccount",
+            apiBaseUrl: "https://mock.api.pagerduty.com",
+            eventsBaseUrl: "https://mock.events.pagerduty.com",
+        };
+
+        insertEndpointConfig(mockAccount);
+        setFallbackEndpointConfig(mockAccount);
+    });
+    
     afterEach(() => {
         jest.clearAllMocks();
     });
@@ -33,11 +45,13 @@ describe("PagerDuty API", () => {
         it.each(testInputs)("should return ok", async () => {
             const expectedId = "P0L1CY1D";
             const expectedName = "Test Escalation Policy";
+            const expectedAccount = "testaccount";
 
             const expectedResponse = [
                 {
                     id: expectedId,
-                    name: expectedName
+                    name: expectedName,
+                    account: expectedAccount
                 }
             ];
 
@@ -120,47 +134,58 @@ describe("PagerDuty API", () => {
         it.each(testInputs)("should work with pagination", async () => {
             const expectedId = ["P0L1CY1D1", "P0L1CY1D2", "P0L1CY1D3", "P0L1CY1D4", "P0L1CY1D5", "P0L1CY1D6", "P0L1CY1D7", "P0L1CY1D8", "P0L1CY1D9", "P0L1CY1D10"];
             const expectedName = ["Test Escalation Policy 1", "Test Escalation Policy 2", "Test Escalation Policy 3", "Test Escalation Policy 4", "Test Escalation Policy 5", "Test Escalation Policy 6", "Test Escalation Policy 7", "Test Escalation Policy 8", "Test Escalation Policy 9", "Test Escalation Policy 10"];
+            const expectedAccount = "testaccount";
 
             const expectedResponse = [
                 {
                     id: expectedId[0],
-                    name: expectedName[0]
+                    name: expectedName[0],
+                    account: expectedAccount
                 },
                 {
                     id: expectedId[1],
-                    name: expectedName[1]
+                    name: expectedName[1],
+                    account: expectedAccount
                 },
                 {
                     id: expectedId[2],
-                    name: expectedName[2]
+                    name: expectedName[2],
+                    account: expectedAccount
                 },
                 {
                     id: expectedId[3],
-                    name: expectedName[3]
+                    name: expectedName[3],
+                    account: expectedAccount
                 },
                 {
                     id: expectedId[4],
-                    name: expectedName[4]
+                    name: expectedName[4],
+                    account: expectedAccount
                 },
                 {
                     id: expectedId[5],
-                    name: expectedName[5]
+                    name: expectedName[5],
+                    account: expectedAccount
                 },
                 {
                     id: expectedId[6],
-                    name: expectedName[6]
+                    name: expectedName[6],
+                    account: expectedAccount
                 },
                 {
                     id: expectedId[7],
-                    name: expectedName[7]
+                    name: expectedName[7],
+                    account: expectedAccount
                 },
                 {
                     id: expectedId[8],
-                    name: expectedName[8]
+                    name: expectedName[8],
+                    account: expectedAccount
                 },
                 {
                     id: expectedId[9],
-                    name: expectedName[9]
+                    name: expectedName[9],
+                    account: expectedAccount
                 }
             ];
 
@@ -694,6 +719,7 @@ describe("PagerDuty API", () => {
                     id: "S3RV1CE1D",
                     name: "Test Service",
                     description: "Test Service Description",
+                    account: "testaccount",
                     html_url: "https://testaccount.pagerduty.com/services/S3RV1CE1D",
                     escalation_policy: {
                         id: "P0L1CY1D",
@@ -707,6 +733,7 @@ describe("PagerDuty API", () => {
                     id: "S3RV1CE2D",
                     name: "Test Service",
                     description: "Test Service Description",
+                    account: "testaccount",
                     html_url: "https://testaccount.pagerduty.com/services/S3RV1CE2D",
                     escalation_policy: {
                         id: "P0L1CY1D",

--- a/src/db/PagerDutyBackendDatabase.ts
+++ b/src/db/PagerDutyBackendDatabase.ts
@@ -8,6 +8,7 @@ export type RawDbEntityResultRow = {
     entityRef: string;
     serviceId: string;
     integrationKey: string;
+    account?: string;
     processedDate?: Date;
 };
 
@@ -47,10 +48,11 @@ export class PagerDutyBackendDatabase implements PagerDutyBackendStore {
                 entityRef: entity.entityRef,
                 serviceId: entity.serviceId,
                 integrationKey: entity.integrationKey,
+                account: entity.account,
                 processedDate: new Date(),
             })
-            .onConflict('serviceId')
-            .merge(['entityRef', 'integrationKey', 'processedDate'])
+            .onConflict(['serviceId'])
+            .merge(['entityRef', 'integrationKey', 'account', 'processedDate'])
             .returning('id');
 
         return result.id;

--- a/src/service/router.ts
+++ b/src/service/router.ts
@@ -42,7 +42,7 @@ export async function createComponentEntitiesReferenceDict({ items: componentEnt
         else if (integrationKey !== undefined && integrationKey !== "") {
             // get service id from integration key, we ignore errors here since we're focused
             // only on building a mapping between valid service IDs and the corresponding Backstage entity
-            const service : PagerDutyService = await getServiceByIntegrationKey(integrationKey, account).catch(() => undefined);
+            const service = await getServiceByIntegrationKey(integrationKey, account).catch(() => undefined);
 
             if (service !== undefined) {
                 componentEntitiesDict[service.id] = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4907,7 +4907,7 @@ __metadata:
     "@backstage/plugin-catalog-node": ^1.12.0
     "@backstage/plugin-scaffolder-node": ^0.4.4
     "@material-ui/core": ^4.12.4
-    "@pagerduty/backstage-plugin-common": 0.1.5
+    "@pagerduty/backstage-plugin-common": 0.2.0
     "@rjsf/core": ^5.14.3
     "@types/express": ^4.17.6
     "@types/node": ^20.9.2
@@ -4931,10 +4931,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@pagerduty/backstage-plugin-common@npm:0.1.5":
-  version: 0.1.5
-  resolution: "@pagerduty/backstage-plugin-common@npm:0.1.5"
-  checksum: 07d527c07aee79d5bb6bf7f310827b11534922c1f817b2cea5cf672ebe393b2def07293b2d42241a033f257139f8d935114edd5e9385dbbc427f8720f20265b6
+"@pagerduty/backstage-plugin-common@npm:0.2.0":
+  version: 0.2.0
+  resolution: "@pagerduty/backstage-plugin-common@npm:0.2.0"
+  checksum: d7243ef9c11408eee046be351346455316dcd8984c33a61d773fec292843d3df9eb9906dfc5ce0ed4fc0c17a60b9b3ebbfe1a8f4a25b8ecc003ffa8d4304db77
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description

This PR introduces the necessary changes to support multi-account configurations. 
- Plugin database now supports account reference
- All PagerDuty API operations are account aware
- Updated plugin configuration schema to accept multi-account configurations

We made extensive tests to ensure that the existing configuration for a single PagerDuty account still works.

**Issue number:** N/A

### Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist

- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [x] Changes are documented
- [x] Changes generate *no new warnings*
- [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

If this is a breaking change 👇

- [ ] I have documented the migration process
- [ ] I have implemented necessary warnings (if it can live side by side)

## Acknowledgement

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer:** We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
