### PR TITLE
feat: service dependency sync

### DIFF
--- a/migrations/20240722_add_settings_table.js
+++ b/migrations/20240722_add_settings_table.js
@@ -1,0 +1,27 @@
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function up(knex) {
+    await knex.schema.createTable('pagerduty_settings', table => {
+        table
+            .string('id')
+            .unique()
+            .notNullable();
+        table
+            .string('value');
+        table
+            .dateTime('updatedAt')
+            .defaultTo(knex.fn.now());
+        table.index(['id'], 'settings_id_idx');
+    });
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.down = async function down(knex) {
+    await knex.schema.alterTable('pagerduty_settings', table => {
+        table.dropIndex([], 'settings_id_idx');
+    });
+    await knex.schema.dropTable('pagerduty_settings');
+};

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@backstage/plugin-catalog-node": "^1.12.0",
     "@backstage/plugin-scaffolder-node": "^0.4.4",
     "@material-ui/core": "^4.12.4",
-    "@pagerduty/backstage-plugin-common": "0.2.0",
+    "@pagerduty/backstage-plugin-common": "0.2.1",
     "@rjsf/core": "^5.14.3",
     "@types/express": "^4.17.6",
     "express": "^4.19.2",

--- a/src/apis/pagerduty.ts
+++ b/src/apis/pagerduty.ts
@@ -22,7 +22,8 @@ import {
     PagerDutyServicesAPIResponse,
     PagerDutyAccountConfig,
     PagerDutyIntegrationResponse,
-    PagerDutyAccountConfig
+    PagerDutyServiceDependency,
+    PagerDutyServiceDependencyResponse,
 } from '@pagerduty/backstage-plugin-common';
 
 import { DateTime } from 'luxon';
@@ -102,6 +103,155 @@ function getApiBaseUrl(account?: string): string {
 }
 
 // Supporting router
+export async function addServiceRelationsToService(serviceRelations: PagerDutyServiceDependency[], account?: string): Promise<PagerDutyServiceDependency[]> {
+    let response: Response;
+    const options: RequestInit = {
+        method: 'POST',
+        headers: {
+            Authorization: await getAuthToken(account),
+            'Accept': 'application/vnd.pagerduty+json;version=2',
+            'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+            relationships: serviceRelations
+        })
+    };
+
+    const apiBaseUrl = getApiBaseUrl(account);
+    const baseUrl = `${apiBaseUrl}/service_dependencies/associate`;
+
+    try {
+        response = await fetchWithRetries(baseUrl, options);
+    } catch (error) {
+        throw new Error(`Failed to retrieve service dependencies: ${error}`);
+    }
+
+    if (response.status >= 500) {
+        throw new HttpError(`Failed to add service dependencies. PagerDuty API returned a server error. Retrying with the same arguments will not work.`, response.status);
+    }
+
+    switch (response.status) {
+        case 400:
+            throw new HttpError("Failed to add service dependencies. Caller provided invalid arguments. Please review the response for error details. Retrying with the same arguments will not work.", 400);
+        case 401:
+            throw new HttpError("Failed to add service dependencies. Caller did not supply credentials or did not provide the correct credentials. If you are using an API key, it may be invalid or your Authorization header may be malformed.", 401);
+        case 403:
+            throw new HttpError("Failed to add service dependencies. Caller is not authorized to view the requested resource. While your authentication is valid, the authenticated user or token does not have permission to perform this action.", 403);
+        case 404:
+            throw new HttpError("Failed to add service dependencies. The requested resource was not found.", 404);
+        default: // 200
+            break;
+    }
+
+    let result: PagerDutyServiceDependencyResponse;
+    try {
+        result = await response.json();
+
+        return result.relationships;
+
+    } catch (error) {
+        throw new HttpError(`Failed to parse service dependency information: ${error}`, 500);
+    }
+}
+
+export async function removeServiceRelationsFromService(serviceRelations: PagerDutyServiceDependency[], account?: string): Promise<PagerDutyServiceDependency[]> {
+    let response: Response;
+    const options: RequestInit = {
+        method: 'POST',
+        headers: {
+            Authorization: await getAuthToken(account),
+            'Accept': 'application/vnd.pagerduty+json;version=2',
+            'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+            relationships: serviceRelations
+        })
+    };
+
+    const apiBaseUrl = getApiBaseUrl(account);
+    const baseUrl = `${apiBaseUrl}/service_dependencies/disassociate`;
+
+    try {
+        response = await fetchWithRetries(`${baseUrl}`, options);
+    } catch (error) {
+        throw new Error(`Failed to retrieve service dependencies: ${error}`);
+    }
+
+    if (response.status >= 500) {
+        throw new HttpError(`Failed to remove service dependencies. PagerDuty API returned a server error. Retrying with the same arguments will not work.`, response.status);
+    }
+
+    switch (response.status) {
+        case 400:
+            throw new HttpError("Failed to remove service dependencies. Caller provided invalid arguments. Please review the response for error details. Retrying with the same arguments will not work.", 400);
+        case 401:
+            throw new HttpError("Failed to remove service dependencies. Caller did not supply credentials or did not provide the correct credentials. If you are using an API key, it may be invalid or your Authorization header may be malformed.", 401);
+        case 403:
+            throw new HttpError("Failed to remove service dependencies. Caller is not authorized to view the requested resource. While your authentication is valid, the authenticated user or token does not have permission to perform this action.", 403);
+        case 404:
+            throw new HttpError("Failed to remove service dependencies. The requested resource was not found.", 404);
+        default: // 200
+            break;
+    }
+
+    let result: PagerDutyServiceDependencyResponse;
+    try {
+        result = await response.json();
+
+        return result.relationships;
+
+    } catch (error) {
+        throw new HttpError(`Failed to parse service dependency information: ${error}`, 500);
+    }
+}
+
+export async function getServiceRelationshipsById(serviceId: string, account?: string): Promise<PagerDutyServiceDependency[]> {
+    let response: Response;
+    const options: RequestInit = {
+        method: 'GET',
+        headers: {
+            Authorization: await getAuthToken(account),
+            'Accept': 'application/vnd.pagerduty+json;version=2',
+            'Content-Type': 'application/json',
+        },
+    };
+
+    const apiBaseUrl = getApiBaseUrl(account);
+    const baseUrl = `${apiBaseUrl}/service_dependencies/technical_services/${serviceId}`;
+
+    try {
+        response = await fetchWithRetries(baseUrl, options);
+    } catch (error) {
+        throw new Error(`Failed to retrieve service dependencies: ${error}`);
+    }
+
+    if (response.status >= 500) {
+        throw new HttpError(`Failed to list service dependencies. PagerDuty API returned a server error. Retrying with the same arguments will not work.`, response.status);
+    }
+
+    switch (response.status) {
+        case 400:
+            throw new HttpError("Failed to list service dependencies. Caller provided invalid arguments. Please review the response for error details. Retrying with the same arguments will not work.", 400);
+        case 401:
+            throw new HttpError("Failed to list service dependencies. Caller did not supply credentials or did not provide the correct credentials. If you are using an API key, it may be invalid or your Authorization header may be malformed.", 401);
+        case 403:
+            throw new HttpError("Failed to list service dependencies. Caller is not authorized to view the requested resource. While your authentication is valid, the authenticated user or token does not have permission to perform this action.", 403);
+        case 404:
+            throw new HttpError("Failed to list service dependencies. The requested resource was not found.", 404);
+        default: // 200
+            break;
+    }
+
+    let result: PagerDutyServiceDependencyResponse;
+    try {
+        result = await response.json();
+
+        return result.relationships;
+    } catch (error) {
+        throw new HttpError(`Failed to parse service dependency information: ${error}`, 500);
+    }
+}
+
 
 async function getEscalationPolicies(offset: number, limit: number, account?: string): Promise<[Boolean, PagerDutyEscalationPolicy[]]> {
     let response: Response;
@@ -119,9 +269,13 @@ async function getEscalationPolicies(offset: number, limit: number, account?: st
     const baseUrl = `${apiBaseUrl}/escalation_policies`;
 
     try {
-        response = await fetch(`${baseUrl}?${params}`, options);
+        response = await fetchWithRetries(`${baseUrl}?${params}`, options);
     } catch (error) {
         throw new Error(`Failed to retrieve escalation policies: ${error}`);
+    }
+
+    if (response.status >= 500) {
+        throw new HttpError(`Failed to list escalation policies. PagerDuty API returned a server error. Retrying with the same arguments will not work.`, response.status);
     }
 
     switch (response.status) {
@@ -208,9 +362,13 @@ export async function isEventNoiseReductionEnabled(account?: string): Promise<bo
     };
 
     try {
-        response = await fetch(`${baseUrl}/abilities`, options);
+        response = await fetchWithRetries(`${baseUrl}/abilities`, options);
     } catch (error) {
         throw new Error(`Failed to read abilities: ${error}`);
+    }
+
+    if (response.status >= 500) {
+        throw new HttpError(`Failed to read abilities. PagerDuty API returned a server error. Retrying with the same arguments will not work.`, response.status);
     }
 
     switch (response.status) {
@@ -256,9 +414,13 @@ export async function getOncallUsers(escalationPolicy: string, account?: string)
     const baseUrl = `${apiBaseUrl}/oncalls`;
 
     try {
-        response = await fetch(`${baseUrl}?${params}`, options);
+        response = await fetchWithRetries(`${baseUrl}?${params}`, options);
     } catch (error) {
         throw new Error(`Failed to retrieve oncalls: ${error}`);
+    }
+
+    if (response.status >= 500) {
+        throw new HttpError(`Failed to list oncalls. PagerDuty API returned a server error. Retrying with the same arguments will not work.`, response.status);
     }
 
     switch (response.status) {
@@ -332,9 +494,13 @@ export async function getServiceById(serviceId: string, account?: string): Promi
     const baseUrl = `${apiBaseUrl}/services`;
 
     try {
-        response = await fetch(`${baseUrl}/${serviceId}?${params}`, options);
+        response = await fetchWithRetries(`${baseUrl}/${serviceId}?${params}`, options);
     } catch (error) {
         throw new Error(`Failed to retrieve service: ${error}`);
+    }
+
+    if (response.status >= 500) {
+        throw new HttpError(`Failed to get service. PagerDuty API returned a server error. Retrying with the same arguments will not work.`, response.status);
     }
 
     switch (response.status) {
@@ -378,9 +544,13 @@ export async function getServiceByIntegrationKey(integrationKey: string, account
     const baseUrl = `${apiBaseUrl}/services`;
 
     try {
-        response = await fetch(`${baseUrl}?${params}`, options);
+        response = await fetchWithRetries(`${baseUrl}?${params}`, options);
     } catch (error) {
         throw new Error(`Failed to retrieve service: ${error}`);
+    }
+
+    if (response.status >= 500) {
+        throw new HttpError(`Failed to get service. PagerDuty API returned a server error. Retrying with the same arguments will not work.`, response.status);
     }
 
     switch (response.status) {
@@ -440,7 +610,11 @@ export async function getAllServices(): Promise<PagerDutyService[]> {
                 do {
                     const paginatedUrl = `${baseUrl}?${params}&offset=${offset}&limit=${limit}`;
 
-                    response = await fetch(paginatedUrl, options);
+                    response = await fetchWithRetries(paginatedUrl, options);
+
+                    if (response.status >= 500) {
+                        throw new HttpError(`Failed to get services. PagerDuty API returned a server error. Retrying with the same arguments will not work.`, response.status);
+                    }
 
                     switch (response.status) {
                         case 400:
@@ -489,9 +663,13 @@ export async function getChangeEvents(serviceId: string, account?: string): Prom
     const baseUrl = `${apiBaseUrl}/services`;
 
     try {
-        response = await fetch(`${baseUrl}/${serviceId}/change_events?${params}`, options);
+        response = await fetchWithRetries(`${baseUrl}/${serviceId}/change_events?${params}`, options);
     } catch (error) {
         throw new Error(`Failed to retrieve change events for service: ${error}`);
+    }
+
+    if (response.status >= 500) {
+        throw new HttpError(`Failed to get change events for service. PagerDuty API returned a server error. Retrying with the same arguments will not work.`, response.status);
     }
 
     switch (response.status) {
@@ -534,9 +712,13 @@ export async function getIncidents(serviceId: string, account?: string): Promise
     const baseUrl = `${apiBaseUrl}/incidents`;
 
     try {
-        response = await fetch(`${baseUrl}?${params}`, options);
+        response = await fetchWithRetries(`${baseUrl}?${params}`, options);
     } catch (error) {
         throw new Error(`Failed to retrieve incidents for service: ${error}`);
+    }
+
+    if (response.status >= 500) {
+        throw new HttpError(`Failed to get incidents for service. PagerDuty API returned a server error. Retrying with the same arguments will not work.`, response.status);
     }
 
     switch (response.status) {
@@ -580,9 +762,13 @@ export async function getServiceStandards(serviceId: string, account?: string): 
     const baseUrl = `${apiBaseUrl}/standards/scores/technical_services/${serviceId}`;
 
     try {
-        response = await fetch(baseUrl, options);
+        response = await fetchWithRetries(baseUrl, options);
     } catch (error) {
         throw new Error(`Failed to retrieve service standards for service: ${error}`);
+    }
+
+    if (response.status >= 500) {
+        throw new HttpError(`Failed to get service standards for service. PagerDuty API returned a server error. Retrying with the same arguments will not work.`, response.status);
     }
 
     switch (response.status) {
@@ -633,9 +819,13 @@ export async function getServiceMetrics(serviceId: string, account?: string): Pr
     const baseUrl = `${apiBaseUrl}/analytics/metrics/incidents/services`;
 
     try {
-        response = await fetch(baseUrl, options);
+        response = await fetchWithRetries(baseUrl, options);
     } catch (error) {
         throw new Error(`Failed to retrieve service metrics for service: ${error}`);
+    }
+
+    if (response.status >= 500) {
+        throw new HttpError(`Failed to get service metrics for service. PagerDuty API returned a server error. Retrying with the same arguments will not work.`, response.status);
     }
 
     switch (response.status) {
@@ -692,9 +882,13 @@ export async function createServiceIntegration({ serviceId, vendorId, account }:
     };
 
     try {
-        response = await fetch(`${baseUrl}/${serviceId}/integrations`, options);
+        response = await fetchWithRetries(`${baseUrl}/${serviceId}/integrations`, options);
     } catch (error) {
         throw new Error(`Failed to create service integration: ${error}`);
+    }
+
+    if (response.status >= 500) {
+        throw new Error(`Failed to create service integration. PagerDuty API returned a server error. Retrying with the same arguments will not work.`);
     }
 
     switch (response.status) {
@@ -721,4 +915,27 @@ export async function createServiceIntegration({ serviceId, vendorId, account }:
     }
 }
 
+export async function fetchWithRetries(url: string, options: RequestInit): Promise<Response> {
+    let response: Response;
+    let error: Error = new Error();
 
+    // set retry parameters
+    const maxRetries = 5;
+    const delay = 1000;
+    let factor = 2;
+
+    for (let i = 0; i < maxRetries; i++) {
+        try {
+            response = await fetch(url, options);
+            return response;
+        } catch (e) {
+            error = e;
+        }
+
+        const timeout = delay * factor;
+        await new Promise(resolve => setTimeout(resolve, timeout));
+        factor *= 2;
+    }
+
+    throw new Error(`Failed to fetch data after ${maxRetries} retries. Last error: ${error}`);
+}

--- a/src/db/PagerDutyBackendDatabase.ts
+++ b/src/db/PagerDutyBackendDatabase.ts
@@ -17,6 +17,7 @@ export interface PagerDutyBackendStore {
     insertEntityMapping(entity: PagerDutyEntityMapping): Promise <string> 
     getAllEntityMappings(): Promise<RawDbEntityResultRow[]>
     findEntityMappingByEntityRef(entityRef: string): Promise<RawDbEntityResultRow | undefined>
+    findEntityMappingByServiceId(serviceId: string): Promise<RawDbEntityResultRow | undefined>
 }
 
 type Options = {
@@ -52,7 +53,7 @@ export class PagerDutyBackendDatabase implements PagerDutyBackendStore {
                 processedDate: new Date(),
             })
             .onConflict(['serviceId'])
-            .merge(['entityRef', 'integrationKey', 'account', 'processedDate'])
+            .merge(['entityRef', 'integrationKey', 'account', 'processedDate'])        
             .returning('id');
 
         return result.id;
@@ -71,6 +72,14 @@ export class PagerDutyBackendDatabase implements PagerDutyBackendStore {
     async findEntityMappingByEntityRef(entityRef: string): Promise<RawDbEntityResultRow | undefined> {
         const rawEntity = await this.db<RawDbEntityResultRow>('pagerduty_entity_mapping')
             .where('entityRef', entityRef)
+            .first();
+
+        return rawEntity;
+    }
+
+    async findEntityMappingByServiceId(serviceId: string): Promise<RawDbEntityResultRow | undefined> {
+        const rawEntity = await this.db<RawDbEntityResultRow>('pagerduty_entity_mapping')
+            .where('serviceId', serviceId)
             .first();
 
         return rawEntity;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4907,7 +4907,7 @@ __metadata:
     "@backstage/plugin-catalog-node": ^1.12.0
     "@backstage/plugin-scaffolder-node": ^0.4.4
     "@material-ui/core": ^4.12.4
-    "@pagerduty/backstage-plugin-common": 0.2.0
+    "@pagerduty/backstage-plugin-common": 0.2.1
     "@rjsf/core": ^5.14.3
     "@types/express": ^4.17.6
     "@types/node": ^20.9.2
@@ -4931,10 +4931,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@pagerduty/backstage-plugin-common@npm:0.2.0":
-  version: 0.2.0
-  resolution: "@pagerduty/backstage-plugin-common@npm:0.2.0"
-  checksum: d7243ef9c11408eee046be351346455316dcd8984c33a61d773fec292843d3df9eb9906dfc5ce0ed4fc0c17a60b9b3ebbfe1a8f4a25b8ecc003ffa8d4304db77
+"@pagerduty/backstage-plugin-common@npm:0.2.1":
+  version: 0.2.1
+  resolution: "@pagerduty/backstage-plugin-common@npm:0.2.1"
+  checksum: 76233c2162d8e7bd3479e13652042cf949911be065f0bf92c5823cbc03c122b8ff49938ca36ab8449da800de7dd9c85724f70e3ff5323e77ef879478394115c9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description

This PR introduces a set of features that were in a way dependent on each other which makes it quite large when compared to a typical PR. 

- **Automated Backstage integration setup for mapped entities**: With the goal of simplifying the setup process for mapped entities we introduced a feature that automatically creates a integration on the corresponding PagerDuty service when a `pagerduty.com/service-id` property is available. 

  With this feature, admins can skip the step of creating an integration in PagerDuty and copy the integration key to each Backstage entity file. They can now simply add the `pagerduty.com/service-id` annotation to their service, or simply use the `PagerDutyPage` to map existing PagerDuty services to Backstage entities and the plugin will take care of the rest. This change is related to #80.

- **Plugin configuration persistence layer**: To support two-way sync for service dependencies we decided to give the admins the option of choosing which is their main source of truth and for that reason we introduced a new section in `PagerDutyPage` where you can specify your preferences. The backend centralises all the persistence layer and this PR includes all the necessary methods for it.

- **Two-way service dependency sync**: This PR introduces a way to keep your service dependencies in sync between PagerDuty and Backstage. Admins will be able to choose which source is the main one (Backstage, PagerDuty, or both). This is an opt-in feature that you can enable on the `PagerDutyPage` under the `configuration` tab.

**Issue number:** [#111](https://github.com/PagerDuty/backstage-plugin/issues/111) from @pagerduty/backstage-plugin

### Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist

- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [ ] Changes are documented
- [x] Changes generate *no new warnings*
- [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

If this is a breaking change 👇

- [ ] I have documented the migration process
- [ ] I have implemented necessary warnings (if it can live side by side)

## Acknowledgement

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer:** We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
