### PR TITLE
fix: add missing "return" statements after errors

### DIFF
--- a/src/service/router.test.ts
+++ b/src/service/router.test.ts
@@ -913,6 +913,12 @@ describe('createRouter', () => {
     });
 
     describe('entity mappings', () => {
+      it("returns a 400 if no serviceId is provided", async () => {
+        const response = await request(app).post('/mapping/entity').send(JSON.stringify({}));
+        expect(response.status).toEqual(400);
+        expect(response.body).toEqual("Bad Request: 'serviceId' must be provided as part of the request body");
+      });
+
       it("creates mapping reference dictionary from service-ids", async () => {
         const mockEntitiesResponse = {
           "items":

--- a/src/service/router.ts
+++ b/src/service/router.ts
@@ -484,7 +484,7 @@ export async function createRouter(
             const entity: PagerDutyEntityMapping = request.body;
 
             if (!entity.serviceId) {
-                response.status(400).json("Bad Request: 'service_id' is required");
+                response.status(400).json("Bad Request: 'serviceId' must be provided as part of the request body");
                 return;
             }
 

--- a/src/service/router.ts
+++ b/src/service/router.ts
@@ -255,11 +255,13 @@ export async function createRouter(
 
             if(serviceId === '') {
                 response.status(400).json("Bad Request: ':serviceId' must be provided as part of the path");
+                return;
             }
 
             const dependencies: string[] = Object.keys(request.body).length === 0 ? [] : request.body;
             if(!dependencies || dependencies.length === 0) {
                 response.status(400).json("Bad Request: 'dependencies' must be provided as part of the request body");
+                return;
             }
 
             const serviceRelations : PagerDutyServiceDependency[] = [];
@@ -302,11 +304,13 @@ export async function createRouter(
 
             if(serviceId === '') {
                 response.status(400).json("Bad Request: ':serviceId' must be provided as part of the path");
+                return;
             }
 
             const dependencies: string[] = Object.keys(request.body).length === 0 ? [] : request.body;
             if(!dependencies || dependencies.length === 0) {
                 response.status(400).json("Bad Request: 'dependencies' must be provided as part of the request body");
+                return;
             }
 
             const serviceRelations : PagerDutyServiceDependency[] = [];
@@ -414,10 +418,12 @@ export async function createRouter(
             await Promise.all(settings.map(async (setting) => {
                 if(setting.id === undefined || setting.value === undefined) {
                     response.status(400).json("Bad Request: 'id' and 'value' are required");
+                    return;
                 }
 
                 if(!isValidSetting(setting.value)) {
                     response.status(400).json("Bad Request: 'value' is invalid. Valid options are 'backstage', 'pagerduty', 'both' or 'disabled'");
+                    return;
                 }
 
                 await store.updateSetting(setting);
@@ -479,6 +485,7 @@ export async function createRouter(
 
             if (!entity.serviceId) {
                 response.status(400).json("Bad Request: 'service_id' is required");
+                return;
             }
 
             // Get all the entity mappings from the database
@@ -698,6 +705,7 @@ export async function createRouter(
 
             if (escalationPolicyId === '') {
                 response.status(400).json("Bad Request: 'escalation_policy_ids[]' is required");
+                return;
             }
 
             const oncallUsers = await getOncallUsers(escalationPolicyId, account);
@@ -726,6 +734,7 @@ export async function createRouter(
 
             if (serviceId === '') {
                 response.status(400).json("Bad Request: ':serviceId' must be provided as part of the path or 'integration_key' as a query parameter");
+                return;
             }
 
             const service = await getServiceById(serviceId, account);
@@ -787,6 +796,7 @@ export async function createRouter(
 
             if (serviceId === '' || vendorId === '') {
                 response.status(400).json("Bad Request: ':serviceId' and ':vendorId' must be provided as part of the path");
+                return;
             }
 
             const integrationKey = await createServiceIntegration({


### PR DESCRIPTION
### Description

When a route function returns an error early on in the function body (i.e. validating the presence of a field), it's important to not continue executing the function to ensure a) no undesired code is executed, and b) to avoid trying to emit headers multiple times.

**Issue number:** n/a

### Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist

- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [ ] Changes are documented
- [x] Changes generate *no new warnings*
- [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

If this is a breaking change 👇

- [ ] I have documented the migration process
- [ ] I have implemented necessary warnings (if it can live side by side)

## Acknowledgement

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer:** We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
