### PR TITLE
fix: fix pluginPackages type

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,13 +10,18 @@
     "types": "dist/index.d.ts"
   },
   "backstage": {
-    "pluginPackages": "pagerduty",
-    "pluginId": "backend",
-    "role": "backend-plugin"
+    "pluginId": "pagerduty",
+    "role": "backend-plugin",
+    "pluginPackages": [
+      "@pagerduty/backstage-plugin",
+      "@pagerduty/backstage-plugin-common",
+      "@pagerduty/backstage-plugin-backend"
+    ]
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/pagerduty/backstage-plugin-backend"
+    "url": "https://github.com/pagerduty/backstage-plugin-backend",
+    "directory": "."
   },
   "homepage": "https://pagerduty.github.io/backstage-plugin-docs/index.html",
   "scripts": {


### PR DESCRIPTION
### Description

The value of `backstage.pluginPackages` is incorrectly set to `pluginId` when it is supposed to represent an array of all the packages that are a part of this plugin. This commit corrects this value to be an array and fixes an issue that prevents the installation of this plugin on certain backstage installations

**Issue number:** N/A

### Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist

- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [x] Changes are documented
- [x] Changes generate *no new warnings*
- [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

If this is a breaking change 👇

- [ ] I have documented the migration process
- [ ] I have implemented necessary warnings (if it can live side by side)

## Acknowledgement

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer:** We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
